### PR TITLE
Speed up CI using ccache

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -54,7 +54,7 @@ jobs:
         cd $GITHUB_WORKSPACE/proxnlp
         mkdir build
         cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/custom_install -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION=OFF
+        cmake .. -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=~/custom_install -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION=OFF
         make -j3 install
 
         echo "PYTHONPATH=/builds/custom_install/lib/python3/dist-packages/" >> $GITHUB_ENV
@@ -66,7 +66,7 @@ jobs:
         cd $GITHUB_WORKSPACE
         mkdir build
         cd build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/custom_install -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION=OFF -DBUILD_CROCODDYL_COMPAT=ON
+        cmake .. -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=~/custom_install -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION=OFF -DBUILD_CROCODDYL_COMPAT=ON
         make -j3 install
         make test
 


### PR DESCRIPTION
Time to compile the dependency proxnlp (if unchanged between two runs) goes down from ~2min40 to 8s.
ProxDDP compile time and test execution went also down from ~5 to 3min30 with a few changes in the source code.

Note: I did the same change on proxnlp/main.