### PR TITLE
ci: start gh-pages workflow for doc

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -1,0 +1,63 @@
+name: gh-pages
+on:
+  push:
+    branches:
+      - '*'
+      - '!gh-pages'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout proxNLP
+        uses: actions/checkout@v3
+        with:
+          ref: main
+          fetch-depth: 0
+          path: ./proxnlp
+          submodules: recursive
+          repository: Simple-Robotics/proxnlp
+          token: ${{ secrets.PROXNLP_TOKEN }}
+
+
+      - name: Install proxnlp
+        run: |
+          cd $GITHUB_WORKSPACE/proxnlp
+          mkdir build
+          cd build
+          cmake .. -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=~/custom_install -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION=OFF
+          make -j3 install
+
+          echo "PYTHONPATH=/builds/custom_install/lib/python3/dist-packages/" >> $GITHUB_ENV
+
+      - name: Build proxdpp doc
+        run: |
+          cd $GITHUB_WORKSPACE
+          mkdir -p build
+          cd build
+          cmake .. -DCMAKE_INSTALL_PREFIX=~/custom_install -DCMAKE_BUILD_TYPE=Release -DPYTHON_EXECUTABLE=$(which python3) -DINSTALL_DOCUMENTATION=ON
+          make doc
+
+      - name: Archive artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: site
+          path: build/doc/doxygen-html
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [build]
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: site
+          path: site
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: site


### PR DESCRIPTION
this adds a workflow that generates the docs and uploads it to gh-pages. I tested the functionality on our self-hosted runner https://github.com/Simple-Robotics/proxddp/runs/7696347444?check_suite_focus=true . Now I switched back to ubuntu-latest, bc in order to activate we need to be a public repo -> once we are public, we have github runner, we have a gh-page :)