### PR TITLE
[minor] Skip tests if BUILD_TESTING is OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,9 @@ if(BUILD_PYTHON_INTERFACE)
 endif()
 
 add_subdirectory(examples)
-add_subdirectory(tests)
+IF(BUILD_TESTING)
+  add_subdirectory(tests)
+ENDIF()
 
 # --- PACKAGING ----------------------------------------------------------------
 macro(EXPORT_VARIABLE var_name var_value)


### PR DESCRIPTION
Same as https://github.com/Simple-Robotics/proxnlp/pull/12

Here it doesn't remove the dependency on google/benchmark as the examples also depend on it.