### PR TITLE
CMake: fetch submodule if not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CMake: fetch submodule if not available in #103
+
 ## [0.4.0] - 2023-12-22
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,19 +24,38 @@ option(INSTALL_DOCUMENTATION "Generate and install the documentation" ON)
 set(DOXYGEN_USE_MATHJAX YES)
 set(DOXYGEN_USE_TEMPLATE_CSS YES)
 
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/base.cmake)
+# Check if the submodule cmake have been initialized
+set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")
+if(NOT EXISTS "${CMAKE_SOURCE_DIR}/cmake/base.cmake")
+  if(${CMAKE_VERSION} VERSION_LESS "3.14.0")
+    message(
+      FATAL_ERROR
+        "\nPlease run the following command first:\ngit submodule update --init\n"
+    )
+  else()
+    message(STATUS "JRL cmakemodules not found. Let's fetch it.")
+    include(FetchContent)
+    FetchContent_Declare(
+      "jrl-cmakemodules"
+      GIT_REPOSITORY "https://github.com/jrl-umi3218/jrl-cmakemodules.git")
+    FetchContent_MakeAvailable("jrl-cmakemodules")
+    FetchContent_GetProperties("jrl-cmakemodules" SOURCE_DIR JRL_CMAKE_MODULES)
+  endif()
+endif()
+
+include(${JRL_CMAKE_MODULES}/base.cmake)
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})
 set(CMAKE_VERBOSE_MAKEFILE OFF)
 
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/boost.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/ide.cmake)
-include(${CMAKE_CURRENT_LIST_DIR}/cmake/apple.cmake)
+include(${JRL_CMAKE_MODULES}/boost.cmake)
+include(${JRL_CMAKE_MODULES}/ide.cmake)
+include(${JRL_CMAKE_MODULES}/apple.cmake)
 if(APPLE) # Use the handmade approach
-  set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP ${CMAKE_MODULE_PATH})
+    set(CMAKE_MODULE_PATH ${JRL_CMAKE_MODULES}/find-external/OpenMP ${CMAKE_MODULE_PATH})
 elseif(UNIX)
   if(${CMAKE_VERSION} VERSION_GREATER "3.20.0" OR ${CMAKE_VERSION} VERSION_EQUAL "3.20.0")
-    set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake/find-external/OpenMP ${CMAKE_MODULE_PATH})
+      set(CMAKE_MODULE_PATH ${JRL_CMAKE_MODULES}/find-external/OpenMP ${CMAKE_MODULE_PATH})
   endif()
 endif(APPLE)
 include(CMakeDependentOption)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,16 +28,12 @@ set(DOXYGEN_USE_TEMPLATE_CSS YES)
 set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")
 if(NOT EXISTS "${CMAKE_SOURCE_DIR}/cmake/base.cmake")
   if(${CMAKE_VERSION} VERSION_LESS "3.14.0")
-    message(
-      FATAL_ERROR
-        "\nPlease run the following command first:\ngit submodule update --init\n"
-    )
+    message(FATAL_ERROR "\nPlease run the following command first:\ngit submodule update --init\n")
   else()
     message(STATUS "JRL cmakemodules not found. Let's fetch it.")
     include(FetchContent)
-    FetchContent_Declare(
-      "jrl-cmakemodules"
-      GIT_REPOSITORY "https://github.com/jrl-umi3218/jrl-cmakemodules.git")
+    FetchContent_Declare("jrl-cmakemodules"
+                         GIT_REPOSITORY "https://github.com/jrl-umi3218/jrl-cmakemodules.git")
     FetchContent_MakeAvailable("jrl-cmakemodules")
     FetchContent_GetProperties("jrl-cmakemodules" SOURCE_DIR JRL_CMAKE_MODULES)
   endif()
@@ -52,10 +48,10 @@ include(${JRL_CMAKE_MODULES}/boost.cmake)
 include(${JRL_CMAKE_MODULES}/ide.cmake)
 include(${JRL_CMAKE_MODULES}/apple.cmake)
 if(APPLE) # Use the handmade approach
-    set(CMAKE_MODULE_PATH ${JRL_CMAKE_MODULES}/find-external/OpenMP ${CMAKE_MODULE_PATH})
+  set(CMAKE_MODULE_PATH ${JRL_CMAKE_MODULES}/find-external/OpenMP ${CMAKE_MODULE_PATH})
 elseif(UNIX)
   if(${CMAKE_VERSION} VERSION_GREATER "3.20.0" OR ${CMAKE_VERSION} VERSION_EQUAL "3.20.0")
-      set(CMAKE_MODULE_PATH ${JRL_CMAKE_MODULES}/find-external/OpenMP ${CMAKE_MODULE_PATH})
+    set(CMAKE_MODULE_PATH ${JRL_CMAKE_MODULES}/find-external/OpenMP ${CMAKE_MODULE_PATH})
   endif()
 endif(APPLE)
 include(CMakeDependentOption)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,9 +1,9 @@
 #
 # Copyright (C) 2022-2023 LAAS-CNRS, INRIA
 #
-include(${PROJECT_SOURCE_DIR}/cmake/python.cmake)
+include(${JRL_CMAKE_MODULES}/python.cmake)
 if(GENERATE_PYTHON_STUBS)
-  include(${PROJECT_SOURCE_DIR}/cmake/stubs.cmake)
+  include(${JRL_CMAKE_MODULES}/stubs.cmake)
 endif(GENERATE_PYTHON_STUBS)
 
 file(GLOB PY_SOURCES src/*.cpp src/modelling/*.cpp)


### PR DESCRIPTION
Hi,

Currently, releases are not pushed with an archive containing the submodule, and the project won't configure without the submodule, so we can't package this project from the tagged releases.

Here is a simple workaround.

On a side note, we should push archives containing the submodule anyway. And a GPG signature would be nice too. There is a command in the jrl cmake module for this. I can help with that too if needed :)