### PR TITLE
CMake: declare dependencies in the main list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CMake: move benchmark dependency speecification in main file
+
 ## [0.4.0] - 2023-12-22
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -282,6 +282,7 @@ if(BUILD_EXAMPLES)
 endif()
 
 if(BUILD_BENCHMARKS)
+  find_package(benchmark REQUIRED)
   add_subdirectory(bench)
 endif()
 

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -2,8 +2,6 @@
 # Copyright (C) 2023 LAAS-CNRS, INRIA
 #
 
-find_package(benchmark REQUIRED)
-
 # Create a benchmark
 function(create_bench exfile croc)
   get_filename_component(exname ${exfile} NAME_WE)


### PR DESCRIPTION
Just to be nice to people trying to build the project who made the effort to read the main CMakeLists to find out what are its dependencies.