### PR TITLE
Fix name of frame parent attribute in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
 - CMake: fetch submodule if not available in #103
 - CMake: move benchmark dependency speecification in main file
+
+### Fixed
+
+- Fix name of frame parent attribute in examples
 
 ## [0.4.0] - 2023-12-22
 

--- a/examples/ur10_ballistic.py
+++ b/examples/ur10_ballistic.py
@@ -88,7 +88,7 @@ def create_rcm():
     # create rigid constraint between ball & tool0
     tool_fid = rmodel.getFrameId("tool0")
     frame: pin.Frame = rmodel.frames[tool_fid]
-    joint1_id = frame.parentJoint
+    joint1_id = frame.parent
     joint2_id = rmodel.getJointId("ball/root_joint")
     pin.framesForwardKinematics(rmodel, rdata, ref_q0)
     pl1 = rmodel.frames[tool_fid].placement

--- a/examples/utils/solo.py
+++ b/examples/utils/solo.py
@@ -14,7 +14,7 @@ FOOT_FRAME_IDS = {
 }
 
 FOOT_JOINT_IDS = {
-    fname: rmodel.frames[fid].parentJoint for fname, fid in FOOT_FRAME_IDS.items()
+    fname: rmodel.frames[fid].parent for fname, fid in FOOT_FRAME_IDS.items()
 }
 
 


### PR DESCRIPTION
In Pinocchio 2.6.21 the attribute is called [`parent`](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/master/doxygen-html/structpinocchio_1_1FrameTpl.html#a2aa4d066ee651eb8fd77bd2ae066ad92).