### PR TITLE
Export definition in CMake config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix name of frame parent attribute in examples
+- Export C++ definitions in CMake config file
 
 ## [0.4.0] - 2023-12-22
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,10 @@ function(create_library)
                VERSION ${PROJECT_VERSION}
                INSTALL_RPATH "\$ORIGIN")
 
+  # Extract the compile definitions of the project for export
+  get_directory_property(CURRENT_COMPILE_DEFINITIONS COMPILE_DEFINITIONS)
+  target_compile_definitions(${PROJECT_NAME} PUBLIC ${CURRENT_COMPILE_DEFINITIONS})
+
   if(BUILD_WITH_PINOCCHIO_SUPPORT)
     target_link_libraries(${PROJECT_NAME} PUBLIC pinocchio::pinocchio)
   endif(BUILD_WITH_PINOCCHIO_SUPPORT)


### PR DESCRIPTION
Export definitions in CMake config file.

This allow to use template instantiation in consumer project by linking against `aligator::aligator`.

The exports are:
- ALIGATOR_ENABLE_TEMPLATE_INSTANTIATION
- ALIGATOR_MULTITHREADING
- ALIGATOR_WITH_PINOCCHIO
- ALIGATOR_WITH_CROCODDYL_COMPAT