### PR TITLE
Remove cnpy dependency for example-talos-arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Finish the se2-car.cpp example #110
 - Add template instantiation for IntegratorAbstract, ExplicitIntegratorAbstract and IntegratorRK2 #114
 - Fix for eigenpy 3.3
+- Don't output numpy matrices in `example-talos-arm`
 
 ### Fixed
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,7 +20,6 @@ create_example(se2-car.cpp)
 
 if(BUILD_CROCODDYL_COMPAT)
   create_example_with_croco(talos-arm.cpp)
-  target_link_libraries(example-talos-arm PRIVATE proxsuite-nlp::cnpy)
   target_add_example_robot_data(example-talos-arm)
 endif()
 

--- a/examples/talos-arm.cpp
+++ b/examples/talos-arm.cpp
@@ -2,7 +2,6 @@
 
 #include "aligator/solvers/proxddp/solver-proxddp.hpp"
 #include "aligator/compat/crocoddyl/problem-wrap.hpp"
-#include <proxsuite-nlp/tests/cnpy.hpp>
 #include <fmt/ostream.h>
 
 using Eigen::MatrixXd;
@@ -14,23 +13,6 @@ constexpr double TOL = 1e-4;
 constexpr std::size_t max_iters = 10;
 
 const std::size_t nsteps = 30;
-#define KKTFILEFORMAT "{}.{:03d}.npy"
-
-struct extract_kkt_matrix_callback : aligator::CallbackBaseTpl<double> {
-  std::string filepath;
-  extract_kkt_matrix_callback(std::string const &filepath)
-      : filepath(filepath) {}
-  void call(const Workspace &ws_, const Results &) {
-    const auto &ws = static_cast<const aligator::context::Workspace &>(ws_);
-    for (std::size_t t = 0; t < ws.kkt_mats_.size(); t++) {
-      MatrixXd const &w = ws.kkt_mats_[t];
-      auto fname = fmt::format(KKTFILEFORMAT, filepath, t);
-      cnpy::npy_save_mat(fname, w);
-      auto fp2 = fmt::format(KKTFILEFORMAT, "kkt_vecs", t);
-      cnpy::npy_save_mat(fp2, ws.kkt_rhs_[t]);
-    }
-  }
-};
 
 int main(int, char **) {
 
@@ -40,8 +22,6 @@ int main(int, char **) {
   double mu_init = 0.01;
   SolverProxDDP<double> solver(TOL, mu_init, 0., max_iters, aligator::VERBOSE);
   std::string fpath_base = "kkt_matrices";
-  solver.registerCallback(
-      "kktcb", std::make_shared<extract_kkt_matrix_callback>(fpath_base));
 
   std::vector<VectorXd> xs_i, us_i;
   getInitialGuesses(croc_problem, xs_i, us_i);


### PR DESCRIPTION
The relevant code is not that useful; this should fix the conda-forge recipe [build error](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=864628&view=logs&j=6f142865-96c3-535c-b7ea-873d86b887bd&t=22b0682d-ab9e-55d7-9c79-49f3c3ba4823)

@jorisv @olivier-roussel 