### PR TITLE
Fix dynamics unittests involving finite difference function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix finite difference function in python unittest ([#128](https://github.com/Simple-Robotics/aligator/pull/128))
+
 ## [0.5.0] - 2024-02-13
 
 ### Added
@@ -34,7 +37,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export C++ definitions in CMake config file
 - Fix Doxyfile python bindings directory ([#110](https://github.com/Simple-Robotics/aligator/pull/110))
 - Fix for eigenpy 3.3 ([#121](https://github.com/Simple-Robotics/aligator/pull/121))
-- Fix finite difference function in python unittest
 
 ## [0.4.0] - 2023-12-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Export C++ definitions in CMake config file
 - Fix Doxyfile python bindings directory ([#110](https://github.com/Simple-Robotics/aligator/pull/110))
 - Fix for eigenpy 3.3 ([#121](https://github.com/Simple-Robotics/aligator/pull/121))
+- Fix finite difference function in python unittest
 
 ## [0.4.0] - 2023-12-22
 

--- a/tests/python/test_continous_dynamics.py
+++ b/tests/python/test_continous_dynamics.py
@@ -89,12 +89,14 @@ def test_multibody_free():
         ode.forward(x0, u0, data)
         ode.dForward(x0, u0, data)
 
-        Jxdiff, Judiff = finite_diff(ode, space, x0, u0)
-
-        err_Jx = np.max(Jxdiff - data.Jx)
-        err_Ju = np.max(Judiff - data.Ju)
-
-        assert err_Jx < epsilon and err_Ju < epsilon
+        Jxdiff, Judiff = finite_diff(ode, space, x0, u0, epsilon)
+        atol = 10 * epsilon
+        assert np.allclose(Jxdiff, data.Jx, atol, atol), "Jxerr={}".format(
+            infNorm(Jxdiff - data.Jx)
+        )
+        assert np.allclose(Judiff, data.Ju, atol, atol), "Juerr={}".format(
+            infNorm(Judiff - data.Ju)
+        )
     except ImportError:
         pass
 

--- a/tests/python/test_continous_dynamics.py
+++ b/tests/python/test_continous_dynamics.py
@@ -10,7 +10,7 @@ from utils import finite_diff
 
 space = manifolds.R3() * manifolds.SO3()
 nu = 0
-epsilon = 1e-6
+epsilon = 1e-4
 
 
 class MyODE(dynamics.ODEAbstract):
@@ -87,6 +87,15 @@ def test_multibody_free():
 
         ode.forward(x0, u0, data)
         ode.dForward(x0, u0, data)
+
+        Jx0 = data.Jx.copy()
+        Ju0 = data.Ju.copy()
+        Jxdiff, Judiff = finite_diff(ode, space, x0, u0)
+
+        err_Jx = np.max(Jxdiff - Jx0)
+        err_Ju = np.max(Judiff - Ju0)
+
+        assert err_Jx < epsilon and err_Ju < epsilon
     except ImportError:
         pass
 
@@ -159,7 +168,7 @@ def test_centroidal_diff():
 
     Jx0 = data.Jx.copy()
     Ju0 = data.Ju.copy()
-    Jxdiff, Judiff = finite_diff(ode, space, x0, u0, epsilon)
+    Jxdiff, Judiff = finite_diff(ode, space, x0, u0)
 
     assert np.linalg.norm(Jxdiff - Jx0) <= epsilon
     assert np.linalg.norm(Judiff - Ju0) <= epsilon
@@ -236,7 +245,7 @@ def test_continuous_centroidal_diff():
 
     Jx0 = data.Jx.copy()
     Ju0 = data.Ju.copy()
-    Jxdiff, Judiff = finite_diff(ode, space, x0, u0, epsilon)
+    Jxdiff, Judiff = finite_diff(ode, space, x0, u0)
 
     assert np.linalg.norm(Jxdiff - Jx0) <= epsilon
     assert np.linalg.norm(Judiff - Ju0) <= epsilon

--- a/tests/python/test_continous_dynamics.py
+++ b/tests/python/test_continous_dynamics.py
@@ -8,7 +8,7 @@ from aligator import dynamics, manifolds
 from pinocchio import Quaternion
 from utils import finite_diff, infNorm
 
-epsilon = 1e-4
+epsilon = 1e-6
 aligator.seed(42)
 np.random.seed(42)
 
@@ -83,7 +83,8 @@ def test_multibody_free():
         assert isinstance(data, dynamics.MultibodyFreeFwdData)
         assert hasattr(data, "tau")
 
-        x0 = space.neutral()
+        x0 = space.rand()
+        x0[:3] = 0.0
         u0 = np.random.randn(nu)
 
         ode.forward(x0, u0, data)

--- a/tests/python/test_continous_dynamics.py
+++ b/tests/python/test_continous_dynamics.py
@@ -10,7 +10,7 @@ from utils import finite_diff
 
 space = manifolds.R3() * manifolds.SO3()
 nu = 0
-epsilon = 1e-4
+epsilon = 1e-3
 
 
 class MyODE(dynamics.ODEAbstract):
@@ -88,12 +88,10 @@ def test_multibody_free():
         ode.forward(x0, u0, data)
         ode.dForward(x0, u0, data)
 
-        Jx0 = data.Jx.copy()
-        Ju0 = data.Ju.copy()
         Jxdiff, Judiff = finite_diff(ode, space, x0, u0)
 
-        err_Jx = np.max(Jxdiff - Jx0)
-        err_Ju = np.max(Judiff - Ju0)
+        err_Jx = np.max(Jxdiff - data.Jx)
+        err_Ju = np.max(Judiff - data.Ju)
 
         assert err_Jx < epsilon and err_Ju < epsilon
     except ImportError:
@@ -166,12 +164,10 @@ def test_centroidal_diff():
     ode.forward(x0, u0, data)
     ode.dForward(x0, u0, data)
 
-    Jx0 = data.Jx.copy()
-    Ju0 = data.Ju.copy()
     Jxdiff, Judiff = finite_diff(ode, space, x0, u0)
 
-    assert np.linalg.norm(Jxdiff - Jx0) <= epsilon
-    assert np.linalg.norm(Judiff - Ju0) <= epsilon
+    assert np.linalg.norm(Jxdiff - data.Jx) <= epsilon
+    assert np.linalg.norm(Judiff - data.Ju) <= epsilon
 
 
 def test_continuous_centroidal():
@@ -243,12 +239,10 @@ def test_continuous_centroidal_diff():
     ode.forward(x0, u0, data)
     ode.dForward(x0, u0, data)
 
-    Jx0 = data.Jx.copy()
-    Ju0 = data.Ju.copy()
     Jxdiff, Judiff = finite_diff(ode, space, x0, u0)
 
-    assert np.linalg.norm(Jxdiff - Jx0) <= epsilon
-    assert np.linalg.norm(Judiff - Ju0) <= epsilon
+    assert np.linalg.norm(Jxdiff - data.Jx) <= epsilon
+    assert np.linalg.norm(Judiff - data.Ju) <= epsilon
 
 
 if __name__ == "__main__":

--- a/tests/python/test_continous_dynamics.py
+++ b/tests/python/test_continous_dynamics.py
@@ -91,7 +91,7 @@ def test_multibody_free():
         ode.dForward(x0, u0, data)
 
         Jxdiff, Judiff = finite_diff(ode, space, x0, u0, epsilon)
-        atol = 10 * epsilon
+        atol = epsilon
         assert np.allclose(Jxdiff, data.Jx, atol, atol), "Jxerr={}".format(
             infNorm(Jxdiff - data.Jx)
         )

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -47,24 +47,29 @@ def finite_diff(dynmodel, space, x, u, EPS=1e-8):
     dx = np.zeros(ndx)
     data = dynmodel.createData()
     dynmodel.forward(x, u, data)
+    # distance to origin
+    _dx = space.difference(space.neutral(), x)
+    ex = EPS * max(1.0, np.linalg.norm(_dx))
     f = data.xdot.copy()
-    fp = f.copy()
     for i in range(ndx):
-        dx[i] = EPS
+        dx[i] = ex
         dynmodel.forward(space.integrate(x, dx), u, data)
-        fp[:] = data.xdot
-        Jx[:, i] = (fp - f) / EPS
+        fp = data.xdot.copy()
+        dynmodel.forward(space.integrate(x, -dx), u, data)
+        fm = data.xdot.copy()
+        Jx[:, i] = (fp - fm) / (2 * ex)
         dx[i] = 0.0
 
     nu = u.shape[0]
+    eu = EPS * max(1.0, np.linalg.norm(u))
     Ju = np.zeros((ndx, nu))
     du = np.zeros(nu)
     data = dynmodel.createData()
     for i in range(nu):
-        du[i] = EPS
+        du[i] = eu
         dynmodel.forward(x, u + du, data)
         fp[:] = data.xdot
-        Ju[:, i] = (fp - f) / EPS
+        Ju[:, i] = (fp - f) / eu
         du[i] = 0.0
 
     return Jx, Ju

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -50,7 +50,7 @@ def finite_diff(dynmodel, space, x, u, EPS=1e-8):
         x_p = space.integrate(x, dx)
         dynmodel.forward(x_p, u, data)
         fp[:] = data.xdot
-        Jx[:, i] = space.difference(f, fp) / EPS
+        Jx[:, i] = (fp - f) / EPS
         dx[i] = 0.0
 
     nu = u.shape[0]
@@ -61,7 +61,7 @@ def finite_diff(dynmodel, space, x, u, EPS=1e-8):
         du[i] = EPS
         dynmodel.forward(x, u + du, data)
         fp[:] = data.xdot
-        Ju[:, i] = space.difference(f, fp) / EPS
+        Ju[:, i] = (fp - f) / EPS
         du[i] = 0.0
 
     return Jx, Ju

--- a/tests/python/utils.py
+++ b/tests/python/utils.py
@@ -3,6 +3,10 @@ import numpy as np
 from aligator import manifolds, dynamics
 
 
+def infNorm(x):
+    return np.linalg.norm(x, np.inf)
+
+
 def create_multibody_ode(humanoid=True):
     try:
         import pinocchio as pin
@@ -47,8 +51,7 @@ def finite_diff(dynmodel, space, x, u, EPS=1e-8):
     fp = f.copy()
     for i in range(ndx):
         dx[i] = EPS
-        x_p = space.integrate(x, dx)
-        dynmodel.forward(x_p, u, data)
+        dynmodel.forward(space.integrate(x, dx), u, data)
         fp[:] = data.xdot
         Jx[:, i] = (fp - f) / EPS
         dx[i] = 0.0


### PR DESCRIPTION
This PR aims at solving issue https://github.com/Simple-Robotics/aligator/issues/127#issue-2131916127 about an error in the finite difference python function used in unittest. It also adds some missing unittest for MultibodyFreeFwdDynamics derivatives. 