### PR TITLE
Add 6D contact option to centroidal dynamics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add kinodynamics forward scheme
 - Add centroidal dynamics derivative cost to regularize the time derivative of centroidal dynamics
 - Add Python example of Solo stepping in place
+- Add wrench cone cost for 6D contact in centroidal dynamics
+- Add a 6D contact formulation for every centroidal cost and dynamics, including kinodynamics
 
 ## [0.5.0] - 2024-02-13
 

--- a/bindings/python/src/modelling/expose-center-of-mass.cpp
+++ b/bindings/python/src/modelling/expose-center-of-mass.cpp
@@ -83,8 +83,9 @@ void exposeCenterOfMassFunctions() {
       "A residual function :math:`r(x) = H_dot` ",
       bp::init<const int, const PinModel &, const context::Vector3s &,
                const std::vector<bool> &,
-               const std::vector<pinocchio::FrameIndex> &>(bp::args(
-          "self", "ndx", "model", "gravity", "contact_states", "contact_ids")))
+               const std::vector<pinocchio::FrameIndex> &, const int>(
+          bp::args("self", "ndx", "model", "gravity", "contact_states",
+                   "contact_ids", "force_size")))
       .def(FrameAPIVisitor<CentroidalMomentumDerivativeResidual>())
       .def_readwrite("contact_states",
                      &CentroidalMomentumDerivativeResidual::contact_states_);

--- a/bindings/python/src/modelling/expose-centroidal.cpp
+++ b/bindings/python/src/modelling/expose-centroidal.cpp
@@ -6,6 +6,7 @@
 #include "aligator/modelling/centroidal/angular-momentum.hpp"
 #include "aligator/modelling/centroidal/centroidal-acceleration.hpp"
 #include "aligator/modelling/centroidal/friction-cone.hpp"
+#include "aligator/modelling/centroidal/wrench-cone.hpp"
 #include "aligator/modelling/centroidal/angular-acceleration.hpp"
 #include "aligator/modelling/centroidal/centroidal-wrapper.hpp"
 #include "aligator/modelling/contact-map.hpp"
@@ -57,6 +58,9 @@ void exposeCentroidalFunctions() {
 
   using FrictionConeResidual = FrictionConeResidualTpl<Scalar>;
   using FrictionConeData = FrictionConeDataTpl<Scalar>;
+
+  using WrenchConeResidual = WrenchConeResidualTpl<Scalar>;
+  using WrenchConeData = WrenchConeDataTpl<Scalar>;
 
   using AngularAccelerationResidual = AngularAccelerationResidualTpl<Scalar>;
   using AngularAccelerationData = AngularAccelerationDataTpl<Scalar>;
@@ -114,8 +118,8 @@ void exposeCentroidalFunctions() {
       "CentroidalAccelerationResidual",
       "A residual function :math:`r(x) = cddot(x)` ",
       bp::init<const int, const int, const double, const context::Vector3s &,
-               const ContactMap &>(
-          bp::args("self", "ndx", "nu", "mass", "gravity", "contact_map")))
+               const ContactMap &, const int>(bp::args(
+          "self", "ndx", "nu", "mass", "gravity", "contact_map", "force_size")))
       .def_readwrite("contact_map",
                      &CentroidalAccelerationResidual::contact_map_)
       .def(CreateDataPythonVisitor<CentroidalAccelerationResidual>());
@@ -137,12 +141,24 @@ void exposeCentroidalFunctions() {
   bp::class_<FrictionConeData, bp::bases<StageFunctionData>>(
       "FrictionConeData", "Data Structure for FrictionCone", bp::no_init);
 
+  bp::class_<WrenchConeResidual, bp::bases<StageFunction>>(
+      "WrenchConeResidual",
+      "A residual function :math:`r(x) = [fz, mu2 * fz2 - (fx2 + fy2)]` ",
+      bp::init<const int, const int, const int, const double, const double,
+               const double, const double>(
+          bp::args("self", "ndx", "nu", "k", "mu", "L", "W", "epsilon")));
+
+  bp::register_ptr_to_python<shared_ptr<WrenchConeData>>();
+
+  bp::class_<WrenchConeData, bp::bases<StageFunctionData>>(
+      "WrenchConeData", "Data Structure for WrenchCone", bp::no_init);
+
   bp::class_<AngularAccelerationResidual, bp::bases<StageFunction>>(
       "AngularAccelerationResidual",
       "A residual function :math:`r(x) = Ldot(x)` ",
       bp::init<const int, const int, const double, const context::Vector3s &,
-               const ContactMap &>(
-          bp::args("self", "ndx", "nu", "mass", "gravity", "contact_map")))
+               const ContactMap &, const int>(bp::args(
+          "self", "ndx", "nu", "mass", "gravity", "contact_map", "force_size")))
       .def_readwrite("contact_map", &AngularAccelerationResidual::contact_map_)
       .def(CreateDataPythonVisitor<AngularAccelerationResidual>());
 
@@ -156,6 +172,8 @@ void exposeCentroidalFunctions() {
       "CentroidalWrapperResidual",
       "A wrapper for centroidal cost with smooth control",
       bp::init<shared_ptr<StageFunction>>(bp::args("self", "centroidal_cost")))
+      .def_readwrite("centroidal_cost",
+                     &CentroidalWrapperResidual::centroidal_cost_)
       .def(CreateDataPythonVisitor<CentroidalWrapperResidual>());
 
   bp::register_ptr_to_python<shared_ptr<CentroidalWrapperData>>();

--- a/bindings/python/src/modelling/expose-centroidal.cpp
+++ b/bindings/python/src/modelling/expose-centroidal.cpp
@@ -145,8 +145,8 @@ void exposeCentroidalFunctions() {
       "WrenchConeResidual",
       "A residual function :math:`r(x) = [fz, mu2 * fz2 - (fx2 + fy2)]` ",
       bp::init<const int, const int, const int, const double, const double,
-               const double, const double>(
-          bp::args("self", "ndx", "nu", "k", "mu", "L", "W", "epsilon")));
+               const double>(
+          bp::args("self", "ndx", "nu", "k", "mu", "L", "W")));
 
   bp::register_ptr_to_python<shared_ptr<WrenchConeData>>();
 

--- a/bindings/python/src/modelling/expose-continuous-dynamics.cpp
+++ b/bindings/python/src/modelling/expose-continuous-dynamics.cpp
@@ -129,8 +129,9 @@ void exposeODEs() {
       "CentroidalFwdDynamics",
       "Nonlinear centroidal dynamics with preplanned feet positions",
       bp::init<const shared_ptr<proxsuite::nlp::VectorSpaceTpl<Scalar>> &,
-               const double, const Vector3s &, const ContactMap &>(
-          bp::args("self", "space", "total mass", "gravity", "contact_map")))
+               const double, const Vector3s &, const ContactMap &, const int>(
+          bp::args("self", "space", "total mass", "gravity", "contact_map",
+                   "force_size")))
       .def_readwrite("contact_map", &CentroidalFwdDynamics::contact_map_)
       .def(CreateDataPythonVisitor<CentroidalFwdDynamics>());
 

--- a/bindings/python/src/modelling/expose-continuous-dynamics.cpp
+++ b/bindings/python/src/modelling/expose-continuous-dynamics.cpp
@@ -144,8 +144,9 @@ void exposeODEs() {
       "Nonlinear centroidal dynamics with preplanned feet positions and smooth "
       "forces",
       bp::init<const shared_ptr<proxsuite::nlp::VectorSpaceTpl<Scalar>> &,
-               const double, const Vector3s &, const ContactMap &>(
-          bp::args("self", "space", "total mass", "gravity", "contact_map")))
+               const double, const Vector3s &, const ContactMap &, const int>(
+          bp::args("self", "space", "total mass", "gravity", "contact_map",
+                   "force_size")))
       .def_readwrite("contact_map",
                      &ContinuousCentroidalFwdDynamics::contact_map_)
       .def(CreateDataPythonVisitor<ContinuousCentroidalFwdDynamics>());

--- a/bindings/python/src/modelling/expose-kinodynamics.cpp
+++ b/bindings/python/src/modelling/expose-kinodynamics.cpp
@@ -29,9 +29,10 @@ void exposeKinodynamics() {
       "Centroidal forward dynamics + kinematics using Pinocchio.",
       bp::init<const ManifoldPtr &, const Model &, const Vector3s &,
                const std::vector<bool> &,
-               const std::vector<pinocchio::FrameIndex> &>(
-          "Constructor.", bp::args("self", "space", "model", "gravity",
-                                   "contact_states", "contact_ids")))
+               const std::vector<pinocchio::FrameIndex> &, const int>(
+          "Constructor.",
+          bp::args("self", "space", "model", "gravity", "contact_states",
+                   "contact_ids", "force_size")))
       .def_readwrite("contact_states",
                      &KinodynamicsFwdDynamics::contact_states_);
 

--- a/examples/solo_kinodynamics.py
+++ b/examples/solo_kinodynamics.py
@@ -31,7 +31,8 @@ pin.updateFramePlacements(rmodel, rdata)
 nq = rmodel.nq
 nv = rmodel.nv
 nk = 4
-nu = nv - 6 + nk * 3
+force_size = 3
+nu = nv - 6 + nk * force_size
 space = manifolds.MultibodyPhaseSpace(rmodel)
 ndx = space.ndx
 
@@ -73,7 +74,7 @@ w_cent_mom = np.diag(w_cent_mom)
 
 def create_dynamics(cont_states):
     ode = dynamics.KinodynamicsFwdDynamics(
-        space, rmodel, gravity, cont_states, feet_ids
+        space, rmodel, gravity, cont_states, feet_ids, force_size
     )
     dyn_model = dynamics.IntegratorEuler(ode, dt)
     return dyn_model
@@ -83,7 +84,7 @@ def createStage(cont_states, cont_pos):
     rcost = aligator.CostStack(space, nu)
 
     cent_mom = aligator.CentroidalMomentumDerivativeResidual(
-        space.ndx, rmodel, gravity, cont_states, feet_ids
+        space.ndx, rmodel, gravity, cont_states, feet_ids, force_size
     )
 
     rcost.addCost(aligator.QuadraticStateCost(space, nu, x0, w_x))
@@ -173,10 +174,10 @@ com_pose = aligator.CenterOfMassTranslationResidual(space.ndx, nu, rmodel, com0)
 stages = [createStage(contact_states[i], contact_poses[i]) for i in range(nsteps)]
 
 cent_mom_cst_ter = aligator.CentroidalMomentumDerivativeResidual(
-    space.ndx, rmodel, gravity, contact_states[-1], feet_ids
+    space.ndx, rmodel, gravity, contact_states[-1], feet_ids, force_size
 )
 cent_mom_cst_init = aligator.CentroidalMomentumDerivativeResidual(
-    space.ndx, rmodel, gravity, contact_states[0], feet_ids
+    space.ndx, rmodel, gravity, contact_states[0], feet_ids, force_size
 )
 stages[0].addConstraint(cent_mom_cst_init, constraints.EqualityConstraintSet())
 stages[-1].addConstraint(cent_mom_cst_ter, constraints.EqualityConstraintSet())

--- a/include/aligator/modelling/centroidal/angular-acceleration.hpp
+++ b/include/aligator/modelling/centroidal/angular-acceleration.hpp
@@ -31,9 +31,11 @@ public:
 
   AngularAccelerationResidualTpl(const int ndx, const int nu, const double mass,
                                  const Vector3s &gravity,
-                                 const ContactMap &contact_map)
-      : Base(ndx, nu, 3), contact_map_(contact_map), nk_(size_t(nu) / 3),
-        mass_(mass), gravity_(gravity) {
+                                 const ContactMap &contact_map,
+                                 const int force_size)
+      : Base(ndx, nu, 3), gravity_(gravity), contact_map_(contact_map),
+        force_size_(force_size), nk_(size_t(nu) / size_t(force_size)),
+        mass_(mass) {
     if (contact_map.getSize() != nk_) {
       ALIGATOR_DOMAIN_ERROR(
           fmt::format("Contact ids and nk should be the same: now "
@@ -58,6 +60,7 @@ protected:
   size_t nk_;
   double mass_;
   Vector3s gravity_;
+  int force_size_;
 };
 
 template <typename Scalar>

--- a/include/aligator/modelling/centroidal/angular-acceleration.hxx
+++ b/include/aligator/modelling/centroidal/angular-acceleration.hxx
@@ -16,13 +16,18 @@ void AngularAccelerationResidualTpl<Scalar>::evaluate(const ConstVectorRef &x,
     long i_ = static_cast<long>(i);
     if (contact_map_.getContactState(i)) {
       d.value_[0] +=
-          (contact_map_.getContactPose(i)[1] - x[1]) * u[i_ * 3 + 2] -
-          (contact_map_.getContactPose(i)[2] - x[2]) * u[i_ * 3 + 1];
-      d.value_[1] += (contact_map_.getContactPose(i)[2] - x[2]) * u[i_ * 3] -
-                     (contact_map_.getContactPose(i)[0] - x[0]) * u[i_ * 3 + 2];
+          (contact_map_.getContactPose(i)[1] - x[1]) * u[i_ * force_size_ + 2] -
+          (contact_map_.getContactPose(i)[2] - x[2]) * u[i_ * force_size_ + 1];
+      d.value_[1] +=
+          (contact_map_.getContactPose(i)[2] - x[2]) * u[i_ * force_size_] -
+          (contact_map_.getContactPose(i)[0] - x[0]) * u[i_ * force_size_ + 2];
       d.value_[2] +=
-          (contact_map_.getContactPose(i)[0] - x[0]) * u[i_ * 3 + 1] -
-          (contact_map_.getContactPose(i)[1] - x[1]) * u[i_ * 3];
+          (contact_map_.getContactPose(i)[0] - x[0]) * u[i_ * force_size_ + 1] -
+          (contact_map_.getContactPose(i)[1] - x[1]) * u[i_ * force_size_];
+      u[i_ * force_size_];
+      if (force_size_ == 6) {
+        d.value_.noalias() += u.template segment<3>(i_ * force_size_ + 3);
+      }
     }
   }
 }
@@ -38,12 +43,12 @@ void AngularAccelerationResidualTpl<Scalar>::computeJacobians(
   for (std::size_t i = 0; i < nk_; i++) {
     long i_ = static_cast<long>(i);
     if (contact_map_.getContactState(i)) {
-      d.Jx_(0, 1) -= u[i_ * 3 + 2];
-      d.Jx_(0, 2) += u[i_ * 3 + 1];
-      d.Jx_(1, 0) += u[i_ * 3 + 2];
-      d.Jx_(1, 2) -= u[i_ * 3];
-      d.Jx_(2, 0) -= u[i_ * 3 + 1];
-      d.Jx_(2, 1) += u[i_ * 3];
+      d.Jx_(0, 1) -= u[i_ * force_size_ + 2];
+      d.Jx_(0, 2) += u[i_ * force_size_ + 1];
+      d.Jx_(1, 0) += u[i_ * force_size_ + 2];
+      d.Jx_(1, 2) -= u[i_ * force_size_];
+      d.Jx_(2, 0) -= u[i_ * force_size_ + 1];
+      d.Jx_(2, 1) += u[i_ * force_size_];
 
       d.Jtemp_ << 0.0, -(contact_map_.getContactPose(i)[2] - x[2]),
           (contact_map_.getContactPose(i)[1] - x[1]),
@@ -52,7 +57,11 @@ void AngularAccelerationResidualTpl<Scalar>::computeJacobians(
           -(contact_map_.getContactPose(i)[1] - x[1]),
           (contact_map_.getContactPose(i)[0] - x[0]), 0.0;
 
-      d.Ju_.template block<3, 3>(0, 3 * i_) = d.Jtemp_;
+      d.Ju_.template block<3, 3>(0, force_size_ * i_) = d.Jtemp_;
+
+      if (force_size_ == 6) {
+        d.Ju_.template block<3, 3>(0, force_size_ * i_ + 3).setIdentity();
+      }
     }
   }
 }

--- a/include/aligator/modelling/centroidal/centroidal-acceleration.hpp
+++ b/include/aligator/modelling/centroidal/centroidal-acceleration.hpp
@@ -31,9 +31,11 @@ public:
 
   CentroidalAccelerationResidualTpl(const int ndx, const int nu,
                                     const double mass, const Vector3s &gravity,
-                                    const ContactMap &contact_map)
-      : Base(ndx, nu, 3), contact_map_(contact_map), nk_(size_t(nu) / 3),
-        mass_(mass), gravity_(gravity) {
+                                    const ContactMap &contact_map,
+                                    const int force_size)
+      : Base(ndx, nu, 3), gravity_(gravity), contact_map_(contact_map),
+        force_size_(force_size), nk_(size_t(nu) / size_t(force_size)),
+        mass_(mass) {
     if (contact_map.getSize() != nk_) {
       ALIGATOR_DOMAIN_ERROR(
           fmt::format("Contact ids and nk should be the same: now "
@@ -58,6 +60,7 @@ protected:
   size_t nk_;
   double mass_;
   Vector3s gravity_;
+  int force_size_;
 };
 
 template <typename Scalar>

--- a/include/aligator/modelling/centroidal/centroidal-acceleration.hxx
+++ b/include/aligator/modelling/centroidal/centroidal-acceleration.hxx
@@ -13,7 +13,7 @@ void CentroidalAccelerationResidualTpl<Scalar>::evaluate(
   d.value_.setZero();
   for (std::size_t i = 0; i < nk_; i++) {
     if (contact_map_.getContactState(i)) {
-      d.value_ += u.template segment<3>(long(i) * 3);
+      d.value_ += u.template segment<3>(long(i) * force_size_);
     }
   }
 
@@ -30,8 +30,8 @@ void CentroidalAccelerationResidualTpl<Scalar>::computeJacobians(
   d.Ju_.setZero();
   for (std::size_t i = 0; i < nk_; i++) {
     if (contact_map_.getContactState(i)) {
-      d.Ju_.template block<3, 3>(0, long(i) * 3).setIdentity();
-      d.Ju_.template block<3, 3>(0, long(i) * 3) *= 1 / mass_;
+      d.Ju_.template block<3, 3>(0, long(i) * force_size_).setIdentity();
+      d.Ju_.template block<3, 3>(0, long(i) * force_size_) *= 1 / mass_;
     }
   }
 }

--- a/include/aligator/modelling/centroidal/wrench-cone.hpp
+++ b/include/aligator/modelling/centroidal/wrench-cone.hpp
@@ -5,15 +5,16 @@
 namespace aligator {
 
 /**
- * @brief This residual implements the "ice cream" friction cone for a
- * centroidal model with state \f$x = (c, h, L) \f$.
+ * @brief This residual implements the wrench cone for a
+ * centroidal model with control \f$u = (f_1,...,f_c) \f$
+ * with \f$f_k\f$ 6D spatial force.
  *
- * @details Considering an unilateral contact k exerting 3D force u,
- * the residual returns a two-dimension array with first component
- * equal to \f$ \epsilon - u_z \f$ (strictly positive normal force
- * condition) and second component equal to * \f$ u_{x,y}^2 -
- * \mu^2 * u_{z}^2 \f$ (non-slippage condition) with \f$ \epsilon
- * \f$ small threshold and \f$ \mu \f$ friction coefficient.
+ * @details Considering an contact k exerting 6D force f,
+ * the residual returns \f$ A f \f$ with \f$A \in \mathbb{R}^{16 \times 6}\f$
+ * the wrench cone matrix gathering Coulomb friction inequalities,
+ * CoP inequalities and limits on vertical torque. The usual
+ * wrench cone approximation with 4 facets is leveraged here.
+ * The frame in contact is supposed to be rectangular.
  */
 
 template <typename Scalar> struct WrenchConeDataTpl;
@@ -29,8 +30,9 @@ public:
   using Data = WrenchConeDataTpl<Scalar>;
 
   WrenchConeResidualTpl(const int ndx, const int nu, const int k,
-                        const double mu, const double L, const double W)
-      : Base(ndx, nu, 16), k_(k), mu_(mu), L_(L), W_(W) {}
+                        const double mu, const double half_length,
+                        const double half_width)
+      : Base(ndx, nu, 16), k_(k), mu_(mu), hL_(half_length), hW_(half_width) {}
 
   void evaluate(const ConstVectorRef &, const ConstVectorRef &u,
                 const ConstVectorRef &, BaseData &data) const;
@@ -43,10 +45,10 @@ public:
   }
 
 protected:
-  int k_;
-  double mu_;
-  double L_;
-  double W_;
+  int k_;     // Contact index corresponding to the contact frame
+  double mu_; // Friction coefficient
+  double hL_; // Half-length of the contact frame
+  double hW_; // Half-width of the contact frame
 };
 
 template <typename Scalar>

--- a/include/aligator/modelling/centroidal/wrench-cone.hpp
+++ b/include/aligator/modelling/centroidal/wrench-cone.hpp
@@ -29,15 +29,13 @@ public:
   using Data = WrenchConeDataTpl<Scalar>;
 
   WrenchConeResidualTpl(const int ndx, const int nu, const int k,
-                        const double mu, const double L, const double W,
-                        const double epsilon)
-      : Base(ndx, nu, 6), k_(k), mu2_(mu * mu), L_(L), W_(W),
-        epsilon_(epsilon) {}
+                        const double mu, const double L, const double W)
+      : Base(ndx, nu, 16), k_(k), mu_(mu), L_(L), W_(W) {}
 
   void evaluate(const ConstVectorRef &, const ConstVectorRef &u,
                 const ConstVectorRef &, BaseData &data) const;
 
-  void computeJacobians(const ConstVectorRef &, const ConstVectorRef &u,
+  void computeJacobians(const ConstVectorRef &, const ConstVectorRef &,
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
@@ -46,17 +44,16 @@ public:
 
 protected:
   int k_;
-  double mu2_;
+  double mu_;
   double L_;
   double W_;
-  double epsilon_;
 };
 
 template <typename Scalar>
 struct WrenchConeDataTpl : StageFunctionDataTpl<Scalar> {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   using Base = StageFunctionDataTpl<Scalar>;
-  using Matrix6s = Eigen::Matrix<Scalar, 6, 6>;
+  using Matrix6s = Eigen::Matrix<Scalar, 16, 6>;
 
   Matrix6s Jtemp_;
 

--- a/include/aligator/modelling/centroidal/wrench-cone.hpp
+++ b/include/aligator/modelling/centroidal/wrench-cone.hpp
@@ -10,7 +10,7 @@ namespace aligator {
  * with \f$f_k\f$ 6D spatial force.
  *
  * @details Considering an contact k exerting 6D force f,
- * the residual returns \f$ A f \f$ with \f$A \in \mathbb{R}^{16 \times 6}\f$
+ * the residual returns \f$ A f \f$ with \f$A \in \mathbb{R}^{17 \times 6}\f$
  * the wrench cone matrix gathering Coulomb friction inequalities,
  * CoP inequalities and limits on vertical torque. The usual
  * wrench cone approximation with 4 facets is leveraged here.
@@ -32,7 +32,7 @@ public:
   WrenchConeResidualTpl(const int ndx, const int nu, const int k,
                         const double mu, const double half_length,
                         const double half_width)
-      : Base(ndx, nu, 16), k_(k), mu_(mu), hL_(half_length), hW_(half_width) {}
+      : Base(ndx, nu, 17), k_(k), mu_(mu), hL_(half_length), hW_(half_width) {}
 
   void evaluate(const ConstVectorRef &, const ConstVectorRef &u,
                 const ConstVectorRef &, BaseData &data) const;
@@ -55,9 +55,8 @@ template <typename Scalar>
 struct WrenchConeDataTpl : StageFunctionDataTpl<Scalar> {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   using Base = StageFunctionDataTpl<Scalar>;
-  using Matrix6s = Eigen::Matrix<Scalar, 16, 6>;
 
-  Matrix6s Jtemp_;
+  Eigen::Matrix<Scalar, 17, 6> Jtemp_;
 
   WrenchConeDataTpl(const WrenchConeResidualTpl<Scalar> *model);
 };

--- a/include/aligator/modelling/centroidal/wrench-cone.hpp
+++ b/include/aligator/modelling/centroidal/wrench-cone.hpp
@@ -16,21 +16,23 @@ namespace aligator {
  * \f$ small threshold and \f$ \mu \f$ friction coefficient.
  */
 
-template <typename Scalar> struct FrictionConeDataTpl;
+template <typename Scalar> struct WrenchConeDataTpl;
 
 template <typename _Scalar>
-struct FrictionConeResidualTpl : StageFunctionTpl<_Scalar> {
+struct WrenchConeResidualTpl : StageFunctionTpl<_Scalar> {
 
 public:
   using Scalar = _Scalar;
   ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
   using Base = StageFunctionTpl<Scalar>;
   using BaseData = typename Base::Data;
-  using Data = FrictionConeDataTpl<Scalar>;
+  using Data = WrenchConeDataTpl<Scalar>;
 
-  FrictionConeResidualTpl(const int ndx, const int nu, const int k,
-                          const double mu, const double epsilon)
-      : Base(ndx, nu, 2), k_(k), mu2_(mu * mu), epsilon_(epsilon) {}
+  WrenchConeResidualTpl(const int ndx, const int nu, const int k,
+                        const double mu, const double L, const double W,
+                        const double epsilon)
+      : Base(ndx, nu, 6), k_(k), mu2_(mu * mu), L_(L), W_(W),
+        epsilon_(epsilon) {}
 
   void evaluate(const ConstVectorRef &, const ConstVectorRef &u,
                 const ConstVectorRef &, BaseData &data) const;
@@ -45,24 +47,26 @@ public:
 protected:
   int k_;
   double mu2_;
+  double L_;
+  double W_;
   double epsilon_;
 };
 
 template <typename Scalar>
-struct FrictionConeDataTpl : StageFunctionDataTpl<Scalar> {
+struct WrenchConeDataTpl : StageFunctionDataTpl<Scalar> {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   using Base = StageFunctionDataTpl<Scalar>;
-  using Matrix23s = Eigen::Matrix<Scalar, 2, 3>;
+  using Matrix6s = Eigen::Matrix<Scalar, 6, 6>;
 
-  Matrix23s Jtemp_;
+  Matrix6s Jtemp_;
 
-  FrictionConeDataTpl(const FrictionConeResidualTpl<Scalar> *model);
+  WrenchConeDataTpl(const WrenchConeResidualTpl<Scalar> *model);
 };
 
 } // namespace aligator
 
-#include "aligator/modelling/centroidal/friction-cone.hxx"
+#include "aligator/modelling/centroidal/wrench-cone.hxx"
 
 #ifdef ALIGATOR_ENABLE_TEMPLATE_INSTANTIATION
-#include "./friction-cone.txx"
+#include "./wrench-cone.txx"
 #endif

--- a/include/aligator/modelling/centroidal/wrench-cone.hxx
+++ b/include/aligator/modelling/centroidal/wrench-cone.hxx
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "aligator/modelling/centroidal/wrench-cone.hpp"
+
+namespace aligator {
+
+template <typename Scalar>
+void WrenchConeResidualTpl<Scalar>::evaluate(const ConstVectorRef &,
+                                             const ConstVectorRef &u,
+                                             const ConstVectorRef &,
+                                             BaseData &data) const {
+  Data &d = static_cast<Data &>(data);
+
+  d.value_[0] = -u[k_ * 6 + 2] + epsilon_;
+  d.value_[1] = -mu2_ * std::pow(u[k_ * 6 + 2], 2) + std::pow(u[k_ * 6], 2) +
+                std::pow(u[k_ * 6 + 1], 2);
+  d.value_[2] = -W_ * u[k_ * 6 + 2] + u[k_ * 6 + 3] + epsilon_;
+  d.value_[3] = -W_ * u[k_ * 6 + 2] - u[k_ * 6 + 3] + epsilon_;
+  d.value_[4] = -L_ * u[k_ * 6 + 2] + u[k_ * 6 + 4] + epsilon_;
+  d.value_[5] = -L_ * u[k_ * 6 + 2] - u[k_ * 6 + 4] + epsilon_;
+}
+
+template <typename Scalar>
+void WrenchConeResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &,
+                                                     const ConstVectorRef &u,
+                                                     const ConstVectorRef &,
+                                                     BaseData &data) const {
+  Data &d = static_cast<Data &>(data);
+
+  d.Jtemp_ << 0, 0, -1, 0, 0, 0, 2 * u[k_ * 6], 2 * u[k_ * 6 + 1],
+      -2 * mu2_ * u[k_ * 6 + 2], 0, 0, 0, 0, 0, -W_, 1, 0, 0, 0, 0, -W_, -1, 0,
+      0, 0, 0, -L_, 0, 1, 0, 0, 0, -L_, 0, -1, 0;
+  d.Ju_.template block<6, 6>(0, k_ * 6) = d.Jtemp_;
+}
+
+template <typename Scalar>
+WrenchConeDataTpl<Scalar>::WrenchConeDataTpl(
+    const WrenchConeResidualTpl<Scalar> *model)
+    : Base(model->ndx1, model->nu, model->ndx2, 6) {
+  Jtemp_.setZero();
+}
+
+} // namespace aligator

--- a/include/aligator/modelling/centroidal/wrench-cone.hxx
+++ b/include/aligator/modelling/centroidal/wrench-cone.hxx
@@ -11,42 +11,45 @@ void WrenchConeResidualTpl<Scalar>::evaluate(const ConstVectorRef &,
                                              BaseData &data) const {
   Data &d = static_cast<Data &>(data);
 
+  // Unilateral contact
+  d.value_[0] = -u[k_ * 6 + 2];
+
   // Coulomb friction inequalities
-  d.value_[0] = -u[k_ * 6] - mu_ * u[k_ * 6 + 2];
-  d.value_[1] = +u[k_ * 6] - mu_ * u[k_ * 6 + 2];
-  d.value_[2] = -u[k_ * 6 + 1] - mu_ * u[k_ * 6 + 2];
-  d.value_[3] = +u[k_ * 6 + 1] - mu_ * u[k_ * 6 + 2];
+  d.value_[1] = -u[k_ * 6] - mu_ * u[k_ * 6 + 2];
+  d.value_[2] = +u[k_ * 6] - mu_ * u[k_ * 6 + 2];
+  d.value_[3] = -u[k_ * 6 + 1] - mu_ * u[k_ * 6 + 2];
+  d.value_[4] = +u[k_ * 6 + 1] - mu_ * u[k_ * 6 + 2];
 
   // Local CoP inequalities
-  d.value_[4] = -hW_ * u[k_ * 6 + 2] - u[k_ * 6 + 3];
-  d.value_[5] = -hW_ * u[k_ * 6 + 2] + u[k_ * 6 + 3];
-  d.value_[6] = -hL_ * u[k_ * 6 + 2] - u[k_ * 6 + 4];
-  d.value_[7] = -hL_ * u[k_ * 6 + 2] + u[k_ * 6 + 4];
+  d.value_[5] = -hW_ * u[k_ * 6 + 2] - u[k_ * 6 + 3];
+  d.value_[6] = -hW_ * u[k_ * 6 + 2] + u[k_ * 6 + 3];
+  d.value_[7] = -hL_ * u[k_ * 6 + 2] - u[k_ * 6 + 4];
+  d.value_[8] = -hL_ * u[k_ * 6 + 2] + u[k_ * 6 + 4];
 
   // z-torque limits
-  d.value_[8] = -hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
+  d.value_[9] = -hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
                 (hW_ + hL_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] +
                 mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
-  d.value_[9] = -hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
-                (hW_ + hL_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] -
-                mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
-  d.value_[10] = hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
+  d.value_[10] = -hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
+                 (hW_ + hL_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] -
+                 mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
+  d.value_[11] = hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
                  (hW_ + hL_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] +
                  mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
-  d.value_[11] = hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
+  d.value_[12] = hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
                  (hW_ + hL_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] -
                  mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
 
-  d.value_[12] = hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
+  d.value_[13] = hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
                  (hW_ + hL_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] +
                  mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
-  d.value_[13] = hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
+  d.value_[14] = hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
                  (hW_ + hL_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] -
                  mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
-  d.value_[14] = -hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
+  d.value_[15] = -hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
                  (hW_ + hL_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] +
                  mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
-  d.value_[15] = -hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
+  d.value_[16] = -hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
                  (hW_ + hL_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] -
                  mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
 }
@@ -58,22 +61,23 @@ void WrenchConeResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &,
                                                      BaseData &data) const {
   Data &d = static_cast<Data &>(data);
 
-  d.Jtemp_ << -1, 0, -mu_, 0, 0, 0, 1, 0, -mu_, 0, 0, 0, 0, -1, -mu_, 0, 0, 0,
-      0, 1, -mu_, 0, 0, 0, 0, 0, -hW_, -1, 0, 0, 0, 0, -hW_, 1, 0, 0, 0, 0,
-      -hL_, 0, -1, 0, 0, 0, -hL_, 0, 1, 0, -hW_, -hL_, -(hL_ + hW_) * mu_, mu_,
-      mu_, -1, -hW_, hL_, -(hL_ + hW_) * mu_, mu_, -mu_, -1, hW_, -hL_,
-      -(hL_ + hW_) * mu_, -mu_, mu_, -1, hW_, hL_, -(hL_ + hW_) * mu_, -mu_,
-      -mu_, -1, hW_, hL_, -(hL_ + hW_) * mu_, mu_, mu_, 1, hW_, -hL_,
-      -(hL_ + hW_) * mu_, mu_, -mu_, 1, -hW_, hL_, -(hL_ + hW_) * mu_, -mu_,
-      mu_, 1, -hW_, -hL_, -(hL_ + hW_) * mu_, -mu_, -mu_, 1;
+  d.Jtemp_ << 0, 0, -1, 0, 0, 0, -1, 0, -mu_, 0, 0, 0, 1, 0, -mu_, 0, 0, 0, 0,
+      -1, -mu_, 0, 0, 0, 0, 1, -mu_, 0, 0, 0, 0, 0, -hW_, -1, 0, 0, 0, 0, -hW_,
+      1, 0, 0, 0, 0, -hL_, 0, -1, 0, 0, 0, -hL_, 0, 1, 0, -hW_, -hL_,
+      -(hL_ + hW_) * mu_, mu_, mu_, -1, -hW_, hL_, -(hL_ + hW_) * mu_, mu_,
+      -mu_, -1, hW_, -hL_, -(hL_ + hW_) * mu_, -mu_, mu_, -1, hW_, hL_,
+      -(hL_ + hW_) * mu_, -mu_, -mu_, -1, hW_, hL_, -(hL_ + hW_) * mu_, mu_,
+      mu_, 1, hW_, -hL_, -(hL_ + hW_) * mu_, mu_, -mu_, 1, -hW_, hL_,
+      -(hL_ + hW_) * mu_, -mu_, mu_, 1, -hW_, -hL_, -(hL_ + hW_) * mu_, -mu_,
+      -mu_, 1;
 
-  d.Ju_.template block<16, 6>(0, k_ * 6) = d.Jtemp_;
+  d.Ju_.template block<17, 6>(0, k_ * 6) = d.Jtemp_;
 }
 
 template <typename Scalar>
 WrenchConeDataTpl<Scalar>::WrenchConeDataTpl(
     const WrenchConeResidualTpl<Scalar> *model)
-    : Base(model->ndx1, model->nu, model->ndx2, 16) {
+    : Base(model->ndx1, model->nu, model->ndx2, 17) {
   Jtemp_.setZero();
 }
 

--- a/include/aligator/modelling/centroidal/wrench-cone.hxx
+++ b/include/aligator/modelling/centroidal/wrench-cone.hxx
@@ -11,39 +11,43 @@ void WrenchConeResidualTpl<Scalar>::evaluate(const ConstVectorRef &,
                                              BaseData &data) const {
   Data &d = static_cast<Data &>(data);
 
+  // Coulomb friction inequalities
   d.value_[0] = -u[k_ * 6] - mu_ * u[k_ * 6 + 2];
   d.value_[1] = +u[k_ * 6] - mu_ * u[k_ * 6 + 2];
   d.value_[2] = -u[k_ * 6 + 1] - mu_ * u[k_ * 6 + 2];
   d.value_[3] = +u[k_ * 6 + 1] - mu_ * u[k_ * 6 + 2];
-  d.value_[4] = -W_ * u[k_ * 6 + 2] - u[k_ * 6 + 3];
-  d.value_[5] = -W_ * u[k_ * 6 + 2] + u[k_ * 6 + 3];
-  d.value_[6] = -L_ * u[k_ * 6 + 2] - u[k_ * 6 + 4];
-  d.value_[7] = -L_ * u[k_ * 6 + 2] + u[k_ * 6 + 4];
 
-  d.value_[8] = -W_ * u[k_ * 6] - L_ * u[k_ * 6 + 1] -
-                (W_ + L_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] +
+  // Local CoP inequalities
+  d.value_[4] = -hW_ * u[k_ * 6 + 2] - u[k_ * 6 + 3];
+  d.value_[5] = -hW_ * u[k_ * 6 + 2] + u[k_ * 6 + 3];
+  d.value_[6] = -hL_ * u[k_ * 6 + 2] - u[k_ * 6 + 4];
+  d.value_[7] = -hL_ * u[k_ * 6 + 2] + u[k_ * 6 + 4];
+
+  // z-torque limits
+  d.value_[8] = -hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
+                (hW_ + hL_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] +
                 mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
-  d.value_[9] = -W_ * u[k_ * 6] + L_ * u[k_ * 6 + 1] -
-                (W_ + L_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] -
+  d.value_[9] = -hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
+                (hW_ + hL_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] -
                 mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
-  d.value_[10] = W_ * u[k_ * 6] - L_ * u[k_ * 6 + 1] -
-                 (W_ + L_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] +
+  d.value_[10] = hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
+                 (hW_ + hL_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] +
                  mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
-  d.value_[11] = W_ * u[k_ * 6] + L_ * u[k_ * 6 + 1] -
-                 (W_ + L_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] -
+  d.value_[11] = hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
+                 (hW_ + hL_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] -
                  mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
 
-  d.value_[12] = W_ * u[k_ * 6] + L_ * u[k_ * 6 + 1] -
-                 (W_ + L_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] +
+  d.value_[12] = hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
+                 (hW_ + hL_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] +
                  mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
-  d.value_[13] = W_ * u[k_ * 6] - L_ * u[k_ * 6 + 1] -
-                 (W_ + L_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] -
+  d.value_[13] = hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
+                 (hW_ + hL_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] -
                  mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
-  d.value_[14] = -W_ * u[k_ * 6] + L_ * u[k_ * 6 + 1] -
-                 (W_ + L_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] +
+  d.value_[14] = -hW_ * u[k_ * 6] + hL_ * u[k_ * 6 + 1] -
+                 (hW_ + hL_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] +
                  mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
-  d.value_[15] = -W_ * u[k_ * 6] - L_ * u[k_ * 6 + 1] -
-                 (W_ + L_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] -
+  d.value_[15] = -hW_ * u[k_ * 6] - hL_ * u[k_ * 6 + 1] -
+                 (hW_ + hL_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] -
                  mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
 }
 
@@ -55,13 +59,13 @@ void WrenchConeResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &,
   Data &d = static_cast<Data &>(data);
 
   d.Jtemp_ << -1, 0, -mu_, 0, 0, 0, 1, 0, -mu_, 0, 0, 0, 0, -1, -mu_, 0, 0, 0,
-      0, 1, -mu_, 0, 0, 0, 0, 0, -W_, -1, 0, 0, 0, 0, -W_, 1, 0, 0, 0, 0, -L_,
-      0, -1, 0, 0, 0, -L_, 0, 1, 0, -W_, -L_, -(L_ + W_) * mu_, mu_, mu_, -1,
-      -W_, L_, -(L_ + W_) * mu_, mu_, -mu_, -1, W_, -L_, -(L_ + W_) * mu_, -mu_,
-      mu_, -1, W_, L_, -(L_ + W_) * mu_, -mu_, -mu_, -1, W_, L_,
-      -(L_ + W_) * mu_, mu_, mu_, 1, W_, -L_, -(L_ + W_) * mu_, mu_, -mu_, 1,
-      -W_, L_, -(L_ + W_) * mu_, -mu_, mu_, 1, -W_, -L_, -(L_ + W_) * mu_, -mu_,
-      -mu_, 1;
+      0, 1, -mu_, 0, 0, 0, 0, 0, -hW_, -1, 0, 0, 0, 0, -hW_, 1, 0, 0, 0, 0,
+      -hL_, 0, -1, 0, 0, 0, -hL_, 0, 1, 0, -hW_, -hL_, -(hL_ + hW_) * mu_, mu_,
+      mu_, -1, -hW_, hL_, -(hL_ + hW_) * mu_, mu_, -mu_, -1, hW_, -hL_,
+      -(hL_ + hW_) * mu_, -mu_, mu_, -1, hW_, hL_, -(hL_ + hW_) * mu_, -mu_,
+      -mu_, -1, hW_, hL_, -(hL_ + hW_) * mu_, mu_, mu_, 1, hW_, -hL_,
+      -(hL_ + hW_) * mu_, mu_, -mu_, 1, -hW_, hL_, -(hL_ + hW_) * mu_, -mu_,
+      mu_, 1, -hW_, -hL_, -(hL_ + hW_) * mu_, -mu_, -mu_, 1;
 
   d.Ju_.template block<16, 6>(0, k_ * 6) = d.Jtemp_;
 }

--- a/include/aligator/modelling/centroidal/wrench-cone.hxx
+++ b/include/aligator/modelling/centroidal/wrench-cone.hxx
@@ -11,32 +11,65 @@ void WrenchConeResidualTpl<Scalar>::evaluate(const ConstVectorRef &,
                                              BaseData &data) const {
   Data &d = static_cast<Data &>(data);
 
-  d.value_[0] = -u[k_ * 6 + 2] + epsilon_;
-  d.value_[1] = -mu2_ * std::pow(u[k_ * 6 + 2], 2) + std::pow(u[k_ * 6], 2) +
-                std::pow(u[k_ * 6 + 1], 2);
-  d.value_[2] = -W_ * u[k_ * 6 + 2] + u[k_ * 6 + 3] + epsilon_;
-  d.value_[3] = -W_ * u[k_ * 6 + 2] - u[k_ * 6 + 3] + epsilon_;
-  d.value_[4] = -L_ * u[k_ * 6 + 2] + u[k_ * 6 + 4] + epsilon_;
-  d.value_[5] = -L_ * u[k_ * 6 + 2] - u[k_ * 6 + 4] + epsilon_;
+  d.value_[0] = -u[k_ * 6] - mu_ * u[k_ * 6 + 2];
+  d.value_[1] = +u[k_ * 6] - mu_ * u[k_ * 6 + 2];
+  d.value_[2] = -u[k_ * 6 + 1] - mu_ * u[k_ * 6 + 2];
+  d.value_[3] = +u[k_ * 6 + 1] - mu_ * u[k_ * 6 + 2];
+  d.value_[4] = -W_ * u[k_ * 6 + 2] - u[k_ * 6 + 3];
+  d.value_[5] = -W_ * u[k_ * 6 + 2] + u[k_ * 6 + 3];
+  d.value_[6] = -L_ * u[k_ * 6 + 2] - u[k_ * 6 + 4];
+  d.value_[7] = -L_ * u[k_ * 6 + 2] + u[k_ * 6 + 4];
+
+  d.value_[8] = -W_ * u[k_ * 6] - L_ * u[k_ * 6 + 1] -
+                (W_ + L_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] +
+                mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
+  d.value_[9] = -W_ * u[k_ * 6] + L_ * u[k_ * 6 + 1] -
+                (W_ + L_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] -
+                mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
+  d.value_[10] = W_ * u[k_ * 6] - L_ * u[k_ * 6 + 1] -
+                 (W_ + L_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] +
+                 mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
+  d.value_[11] = W_ * u[k_ * 6] + L_ * u[k_ * 6 + 1] -
+                 (W_ + L_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] -
+                 mu_ * u[k_ * 6 + 4] - u[k_ * 6 + 5];
+
+  d.value_[12] = W_ * u[k_ * 6] + L_ * u[k_ * 6 + 1] -
+                 (W_ + L_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] +
+                 mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
+  d.value_[13] = W_ * u[k_ * 6] - L_ * u[k_ * 6 + 1] -
+                 (W_ + L_) * mu_ * u[k_ * 6 + 2] + mu_ * u[k_ * 6 + 3] -
+                 mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
+  d.value_[14] = -W_ * u[k_ * 6] + L_ * u[k_ * 6 + 1] -
+                 (W_ + L_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] +
+                 mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
+  d.value_[15] = -W_ * u[k_ * 6] - L_ * u[k_ * 6 + 1] -
+                 (W_ + L_) * mu_ * u[k_ * 6 + 2] - mu_ * u[k_ * 6 + 3] -
+                 mu_ * u[k_ * 6 + 4] + u[k_ * 6 + 5];
 }
 
 template <typename Scalar>
 void WrenchConeResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &,
-                                                     const ConstVectorRef &u,
+                                                     const ConstVectorRef &,
                                                      const ConstVectorRef &,
                                                      BaseData &data) const {
   Data &d = static_cast<Data &>(data);
 
-  d.Jtemp_ << 0, 0, -1, 0, 0, 0, 2 * u[k_ * 6], 2 * u[k_ * 6 + 1],
-      -2 * mu2_ * u[k_ * 6 + 2], 0, 0, 0, 0, 0, -W_, 1, 0, 0, 0, 0, -W_, -1, 0,
-      0, 0, 0, -L_, 0, 1, 0, 0, 0, -L_, 0, -1, 0;
-  d.Ju_.template block<6, 6>(0, k_ * 6) = d.Jtemp_;
+  d.Jtemp_ << -1, 0, -mu_, 0, 0, 0, 1, 0, -mu_, 0, 0, 0, 0, -1, -mu_, 0, 0, 0,
+      0, 1, -mu_, 0, 0, 0, 0, 0, -W_, -1, 0, 0, 0, 0, -W_, 1, 0, 0, 0, 0, -L_,
+      0, -1, 0, 0, 0, -L_, 0, 1, 0, -W_, -L_, -(L_ + W_) * mu_, mu_, mu_, -1,
+      -W_, L_, -(L_ + W_) * mu_, mu_, -mu_, -1, W_, -L_, -(L_ + W_) * mu_, -mu_,
+      mu_, -1, W_, L_, -(L_ + W_) * mu_, -mu_, -mu_, -1, W_, L_,
+      -(L_ + W_) * mu_, mu_, mu_, 1, W_, -L_, -(L_ + W_) * mu_, mu_, -mu_, 1,
+      -W_, L_, -(L_ + W_) * mu_, -mu_, mu_, 1, -W_, -L_, -(L_ + W_) * mu_, -mu_,
+      -mu_, 1;
+
+  d.Ju_.template block<16, 6>(0, k_ * 6) = d.Jtemp_;
 }
 
 template <typename Scalar>
 WrenchConeDataTpl<Scalar>::WrenchConeDataTpl(
     const WrenchConeResidualTpl<Scalar> *model)
-    : Base(model->ndx1, model->nu, model->ndx2, 6) {
+    : Base(model->ndx1, model->nu, model->ndx2, 16) {
   Jtemp_.setZero();
 }
 

--- a/include/aligator/modelling/centroidal/wrench-cone.txx
+++ b/include/aligator/modelling/centroidal/wrench-cone.txx
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "aligator/context.hpp"
+#include "aligator/modelling/centroidal/wrench-cone.hpp"
+
+namespace aligator {
+
+extern template struct WrenchConeResidualTpl<context::Scalar>;
+extern template struct WrenchConeDataTpl<context::Scalar>;
+
+} // namespace aligator

--- a/include/aligator/modelling/dynamics/centroidal-fwd.hpp
+++ b/include/aligator/modelling/dynamics/centroidal-fwd.hpp
@@ -41,12 +41,13 @@ struct CentroidalFwdDynamicsTpl : ODEAbstractTpl<_Scalar> {
   double mass_;
   Vector3s gravity_;
   ContactMap contact_map_;
+  int force_size_;
 
   const Manifold &space() const { return *space_; }
 
   CentroidalFwdDynamicsTpl(const ManifoldPtr &state, const double mass,
                            const Vector3s &gravity,
-                           const ContactMap &contact_map);
+                           const ContactMap &contact_map, const int force_size);
 
   void forward(const ConstVectorRef &x, const ConstVectorRef &u,
                BaseData &data) const;

--- a/include/aligator/modelling/dynamics/continuous-centroidal-fwd.hpp
+++ b/include/aligator/modelling/dynamics/continuous-centroidal-fwd.hpp
@@ -42,12 +42,14 @@ struct ContinuousCentroidalFwdDynamicsTpl : ODEAbstractTpl<_Scalar> {
   double mass_;
   Vector3s gravity_;
   ContactMap contact_map_;
+  int force_size_;
 
   const Manifold &space() const { return *space_; }
 
   ContinuousCentroidalFwdDynamicsTpl(const ManifoldPtr &state,
                                      const double mass, const Vector3s &gravity,
-                                     const ContactMap &contact_map);
+                                     const ContactMap &contact_map,
+                                     const int force_size);
 
   void forward(const ConstVectorRef &x, const ConstVectorRef &u,
                BaseData &data) const;

--- a/include/aligator/modelling/dynamics/kinodynamics-fwd.hpp
+++ b/include/aligator/modelling/dynamics/kinodynamics-fwd.hpp
@@ -44,6 +44,7 @@ struct KinodynamicsFwdDynamicsTpl : ODEAbstractTpl<_Scalar> {
   Model pin_model_;
   double mass_;
   Vector3s gravity_;
+  int force_size_;
 
   std::vector<bool> contact_states_;
   std::vector<pinocchio::FrameIndex> contact_ids_;
@@ -53,7 +54,8 @@ struct KinodynamicsFwdDynamicsTpl : ODEAbstractTpl<_Scalar> {
   KinodynamicsFwdDynamicsTpl(
       const ManifoldPtr &state, const Model &model, const Vector3s &gravity,
       const std::vector<bool> &contact_states,
-      const std::vector<pinocchio::FrameIndex> &contact_ids);
+      const std::vector<pinocchio::FrameIndex> &contact_ids,
+      const int force_size);
 
   void forward(const ConstVectorRef &x, const ConstVectorRef &u,
                BaseData &data) const;

--- a/include/aligator/modelling/dynamics/kinodynamics-fwd.hxx
+++ b/include/aligator/modelling/dynamics/kinodynamics-fwd.hxx
@@ -29,12 +29,6 @@ KinodynamicsFwdDynamicsTpl<Scalar>::KinodynamicsFwdDynamicsTpl(
                     "now ({} and {}).",
                     contact_ids_.size(), contact_states_.size()));
   }
-  /* if (force_size_ != 3 or force_size_ != 6) {
-    ALIGATOR_DOMAIN_ERROR(
-        fmt::format("force size should be of size "
-                    "{} or {}.",
-                    3, 6));
-  } */
 }
 
 template <typename Scalar>

--- a/include/aligator/modelling/multibody/centroidal-momentum-derivative.hpp
+++ b/include/aligator/modelling/multibody/centroidal-momentum-derivative.hpp
@@ -32,14 +32,16 @@ public:
   Vector3s gravity_;
   std::vector<bool> contact_states_;
   std::vector<pinocchio::FrameIndex> contact_ids_;
+  int force_size_;
 
   CentroidalMomentumDerivativeResidualTpl(
       const int ndx, const Model &model, const Vector3s &gravity,
       const std::vector<bool> &contact_states,
-      const std::vector<pinocchio::FrameIndex> &contact_ids)
-      : Base(ndx, (int)contact_states.size() * 3 + model.nv - 6, 6),
+      const std::vector<pinocchio::FrameIndex> &contact_ids,
+      const int force_size)
+      : Base(ndx, (int)contact_states.size() * force_size + model.nv - 6, 6),
         pin_model_(model), gravity_(gravity), contact_states_(contact_states),
-        contact_ids_(contact_ids) {
+        contact_ids_(contact_ids), force_size_(force_size) {
     mass_ = pinocchio::computeTotalMass(model);
     if (contact_ids_.size() != contact_states_.size()) {
       ALIGATOR_DOMAIN_ERROR(

--- a/include/aligator/modelling/multibody/centroidal-momentum-derivative.hxx
+++ b/include/aligator/modelling/multibody/centroidal-momentum-derivative.hxx
@@ -26,23 +26,27 @@ void CentroidalMomentumDerivativeResidualTpl<Scalar>::evaluate(
   for (std::size_t i = 0; i < contact_states_.size(); i++) {
     if (contact_states_[i]) {
       long i_ = static_cast<long>(i);
-      d.value_.template head<3>() += u.template segment<3>(i_ * 3);
+      d.value_.template head<3>() += u.template segment<3>(i_ * force_size_);
       pinocchio::updateFramePlacement(pin_model_, pdata, contact_ids_[i]);
       d.value_[3] +=
           (pdata.oMf[contact_ids_[i]].translation()[1] - pdata.com[0][1]) *
-              u[i_ * 3 + 2] -
+              u[i_ * force_size_ + 2] -
           (pdata.oMf[contact_ids_[i]].translation()[2] - pdata.com[0][2]) *
-              u[i_ * 3 + 1];
+              u[i_ * force_size_ + 1];
       d.value_[4] +=
           (pdata.oMf[contact_ids_[i]].translation()[2] - pdata.com[0][2]) *
-              u[i_ * 3] -
+              u[i_ * force_size_] -
           (pdata.oMf[contact_ids_[i]].translation()[0] - pdata.com[0][0]) *
-              u[i_ * 3 + 2];
+              u[i_ * force_size_ + 2];
       d.value_[5] +=
           (pdata.oMf[contact_ids_[i]].translation()[0] - pdata.com[0][0]) *
-              u[i_ * 3 + 1] -
+              u[i_ * force_size_ + 1] -
           (pdata.oMf[contact_ids_[i]].translation()[1] - pdata.com[0][1]) *
-              u[i_ * 3];
+              u[i_ * force_size_];
+      if (force_size_ == 6) {
+        d.value_.template tail<3>() +=
+            u.template segment<3>(i_ * force_size_ + 3);
+      }
     }
   }
 }
@@ -66,8 +70,9 @@ void CentroidalMomentumDerivativeResidualTpl<Scalar>::computeJacobians(
       d.fJf_.setZero();
       pinocchio::getFrameJacobian(pin_model_, pdata, contact_ids_[i],
                                   pinocchio::LOCAL_WORLD_ALIGNED, d.fJf_);
-      d.Jtemp_ << 0, -u[i_ * 3 + 2], u[i_ * 3 + 1], u[i_ * 3 + 2], 0,
-          -u[i_ * 3], -u[i_ * 3 + 1], u[i_ * 3], 0;
+      d.Jtemp_ << 0, -u[i_ * force_size_ + 2], u[i_ * force_size_ + 1],
+          u[i_ * force_size_ + 2], 0, -u[i_ * force_size_],
+          -u[i_ * force_size_ + 1], u[i_ * force_size_], 0;
       d.Jx_.bottomLeftCorner(3, pin_model_.nv) +=
           d.Jtemp_ * (pdata.Jcom - d.fJf_.template topRows<3>());
     }
@@ -85,8 +90,11 @@ void CentroidalMomentumDerivativeResidualTpl<Scalar>::computeJacobians(
           -(pdata.oMf[contact_ids_[i]].translation()[1] - pdata.com[0][1]),
           (pdata.oMf[contact_ids_[i]].translation()[0] - pdata.com[0][0]), 0.0;
 
-      d.Ju_.template block<3, 3>(0, 3 * i_).setIdentity();
-      d.Ju_.template block<3, 3>(3, 3 * i_) = d.Jtemp_;
+      d.Ju_.template block<3, 3>(0, force_size_ * i_).setIdentity();
+      d.Ju_.template block<3, 3>(3, force_size_ * i_) = d.Jtemp_;
+      if (force_size_ == 6) {
+        d.Ju_.template block<3, 3>(3, force_size_ * i_ + 3).setIdentity();
+      }
     }
   }
 }

--- a/src/modelling/centroidal/wrench-cone.cpp
+++ b/src/modelling/centroidal/wrench-cone.cpp
@@ -1,0 +1,8 @@
+#include "aligator/modelling/centroidal/wrench-cone.hpp"
+
+namespace aligator {
+
+template struct WrenchConeResidualTpl<context::Scalar>;
+template struct WrenchConeDataTpl<context::Scalar>;
+
+} // namespace aligator

--- a/tests/python/test_centroidal.py
+++ b/tests/python/test_centroidal.py
@@ -139,6 +139,8 @@ def test_angular_momentum():
 
 def test_acceleration():
     x, d, x0 = sample_gauss(space)
+    force_size = 3
+    nu = force_size * nk
     u0 = np.random.randn(nu)
 
     contact_states = [True, False, True, True]
@@ -150,14 +152,56 @@ def test_acceleration():
     ]
     contact_map = aligator.ContactMap(contact_states, contact_poses)
 
-    fun = aligator.CentroidalAccelerationResidual(ndx, nu, mass, gravity, contact_map)
+    fun = aligator.CentroidalAccelerationResidual(
+        ndx, nu, mass, gravity, contact_map, force_size
+    )
     fdata = fun.createData()
     fun.evaluate(x0, u0, x0, fdata)
 
     comddot = np.zeros(3)
     for i in range(nk):
         if fun.contact_map.contact_states[i]:
-            comddot += u0[i * 3 : (i + 1) * 3]
+            comddot += u0[i * force_size : i * force_size + 3]
+
+    comddot /= mass
+    comddot += gravity
+
+    assert np.allclose(fdata.value, comddot)
+
+    fun_fd = aligator.FiniteDifferenceHelper(space, fun, FD_EPS)
+    fdata2 = fun_fd.createData()
+    fun_fd.evaluate(x0, u0, x0, fdata2)
+    assert np.allclose(fdata.value, fdata2.value)
+
+    fun_fd.computeJacobians(x0, u0, x0, fdata2)
+    J_fd = fdata2.Jx
+    J_fd_u = fdata2.Ju
+    assert fdata.Jx.shape == J_fd.shape
+    assert fdata.Ju.shape == J_fd_u.shape
+
+    for i in range(100):
+        du = np.random.randn(nu) * 0.1
+        u1 = u0 + du
+        fun.evaluate(x0, u1, x0, fdata)
+        fun.computeJacobians(x0, u1, x0, fdata)
+        fun_fd.evaluate(x0, u1, x0, fdata2)
+        fun_fd.computeJacobians(x0, u1, x0, fdata2)
+        assert np.allclose(fdata.Ju, fdata2.Ju, THRESH)
+
+    force_size = 6
+    nu = force_size * nk
+    u0 = np.random.randn(nu)
+
+    fun = aligator.CentroidalAccelerationResidual(
+        ndx, nu, mass, gravity, contact_map, force_size
+    )
+    fdata = fun.createData()
+    fun.evaluate(x0, u0, x0, fdata)
+
+    comddot = np.zeros(3)
+    for i in range(nk):
+        if fun.contact_map.contact_states[i]:
+            comddot += u0[i * force_size : i * force_size + 3]
 
     comddot /= mass
     comddot += gravity
@@ -187,6 +231,7 @@ def test_acceleration():
 
 def test_friction_cone():
     x, d, x0 = sample_gauss(space)
+    nu = 3 * nk
     u0 = np.random.randn(nu)
     k = 2
     mu = 0.5
@@ -223,8 +268,60 @@ def test_friction_cone():
         assert np.allclose(fdata.Ju, fdata2.Ju, THRESH)
 
 
+def test_wrench_cone():
+    x, d, x0 = sample_gauss(space)
+    force_size = 6
+    nu = force_size * nk
+    u0 = np.random.randn(nu)
+    k = 2
+    mu = 0.5
+    epsilon = 1e-3
+    L = 0.1
+    W = 0.05
+
+    fun = aligator.WrenchConeResidual(ndx, nu, k, mu, L, W, epsilon)
+
+    fdata = fun.createData()
+    fun.evaluate(x0, u0, x0, fdata)
+    fcone = np.zeros(6)
+    fcone[0] = epsilon - u0[k * force_size + 2]
+    fcone[1] = (
+        -(mu**2) * u0[k * force_size + 2] ** 2
+        + u0[k * force_size] ** 2
+        + u0[k * force_size + 1] ** 2
+    )
+    fcone[2] = -W * u0[k * force_size + 2] + u0[k * force_size + 3]
+    fcone[3] = -W * u0[k * force_size + 2] - u0[k * force_size + 3]
+    fcone[4] = -L * u0[k * force_size + 2] + u0[k * force_size + 4]
+    fcone[5] = -L * u0[k * force_size + 2] - u0[k * force_size + 4]
+
+    assert np.allclose(fdata.value, fcone)
+
+    fun_fd = aligator.FiniteDifferenceHelper(space, fun, FD_EPS)
+    fdata2 = fun_fd.createData()
+    fun_fd.evaluate(x0, u0, x0, fdata2)
+    assert np.allclose(fdata.value, fdata2.value)
+
+    fun_fd.computeJacobians(x0, u0, x0, fdata2)
+    J_fd = fdata2.Jx
+    J_fd_u = fdata2.Ju
+    assert fdata.Jx.shape == J_fd.shape
+    assert fdata.Ju.shape == J_fd_u.shape
+
+    for i in range(100):
+        du = np.random.randn(nu) * sample_factor
+        u1 = u0 + du
+        fun.evaluate(x0, u1, x0, fdata)
+        fun.computeJacobians(x0, u1, x0, fdata)
+        fun_fd.evaluate(x0, u1, x0, fdata2)
+        fun_fd.computeJacobians(x0, u1, x0, fdata2)
+        assert np.allclose(fdata.Ju, fdata2.Ju, THRESH)
+
+
 def test_angular_acceleration():
     x, d, x0 = sample_gauss(space)
+    force_size = 3
+    nu = force_size * nk
     u0 = np.random.randn(nu)
     contact_states = [True, False, True, True]
     contact_poses = [
@@ -235,7 +332,9 @@ def test_angular_acceleration():
     ]
     contact_map = aligator.ContactMap(contact_states, contact_poses)
 
-    fun = aligator.AngularAccelerationResidual(ndx, nu, mass, gravity, contact_map)
+    fun = aligator.AngularAccelerationResidual(
+        ndx, nu, mass, gravity, contact_map, force_size
+    )
     fdata = fun.createData()
 
     fun.evaluate(x0, u0, x0, fdata)
@@ -269,12 +368,54 @@ def test_angular_acceleration():
         assert np.allclose(fdata.Ju, fdata2.Ju, THRESH)
         assert np.allclose(fdata.Jx, fdata2.Jx, THRESH)
 
+    force_size = 6
+    nu = force_size * nk
+    u0 = np.random.randn(nu)
+
+    fun = aligator.AngularAccelerationResidual(
+        ndx, nu, mass, gravity, contact_map, force_size
+    )
+    fdata = fun.createData()
+
+    fun.evaluate(x0, u0, x0, fdata)
+
+    Ldot = np.zeros(3)
+    for i in range(nk):
+        if contact_states[i]:
+            Ldot += np.cross(contact_poses[i] - x0[:3], u0[i * 6 : i * 6 + 3])
+            Ldot += u0[i * 6 + 3 : (i + 1) * 6]
+
+    assert np.allclose(fdata.value, Ldot)
+
+    fun_fd = aligator.FiniteDifferenceHelper(space, fun, FD_EPS)
+    fdata2 = fun_fd.createData()
+    fun_fd.evaluate(x0, u0, x0, fdata2)
+    assert np.allclose(fdata.value, fdata2.value)
+
+    fun_fd.computeJacobians(x0, u0, x0, fdata2)
+    J_fd = fdata2.Jx
+    J_fd_u = fdata2.Ju
+    assert fdata.Jx.shape == J_fd.shape
+    assert fdata.Ju.shape == J_fd_u.shape
+
+    for i in range(100):
+        du = np.random.randn(nu) * sample_factor
+        u1 = u0 + du
+        x, d, x0 = sample_gauss(space)
+        fun.evaluate(x0, u1, x0, fdata)
+        fun.computeJacobians(x0, u1, x0, fdata)
+        fun_fd.evaluate(x0, u1, x0, fdata2)
+        fun_fd.computeJacobians(x0, u1, x0, fdata2)
+        assert np.allclose(fdata.Ju, fdata2.Ju, THRESH)
+        assert np.allclose(fdata.Jx, fdata2.Jx, THRESH)
+
 
 def test_wrapper_angular_acceleration():
     wx, d, wx0 = sample_gauss(space)
     wu0 = np.random.randn(nu)
 
-    ndx_w = 9 + nk * 3
+    force_size = 3
+    ndx_w = 9 + nk * force_size
     x0 = np.concatenate((wx0, wu0))
     u0 = np.random.randn(nu)
     wrapping_space = manifolds.VectorSpace(ndx_w)
@@ -289,7 +430,7 @@ def test_wrapper_angular_acceleration():
     contact_map = aligator.ContactMap(contact_states, contact_poses)
 
     wrapped_fun = aligator.AngularAccelerationResidual(
-        ndx, nu, mass, gravity, contact_map
+        ndx, nu, mass, gravity, contact_map, force_size
     )
     fun = aligator.CentroidalWrapperResidual(wrapped_fun)
 

--- a/tests/python/test_centroidal.py
+++ b/tests/python/test_centroidal.py
@@ -275,28 +275,13 @@ def test_wrench_cone():
     u0 = np.random.randn(nu)
     k = 2
     mu = 0.5
-    epsilon = 1e-3
     L = 0.1
     W = 0.05
 
-    fun = aligator.WrenchConeResidual(ndx, nu, k, mu, L, W, epsilon)
-
+    fun = aligator.WrenchConeResidual(ndx, nu, k, mu, L, W)
     fdata = fun.createData()
+
     fun.evaluate(x0, u0, x0, fdata)
-    fcone = np.zeros(6)
-    fcone[0] = epsilon - u0[k * force_size + 2]
-    fcone[1] = (
-        -(mu**2) * u0[k * force_size + 2] ** 2
-        + u0[k * force_size] ** 2
-        + u0[k * force_size + 1] ** 2
-    )
-    fcone[2] = -W * u0[k * force_size + 2] + u0[k * force_size + 3]
-    fcone[3] = -W * u0[k * force_size + 2] - u0[k * force_size + 3]
-    fcone[4] = -L * u0[k * force_size + 2] + u0[k * force_size + 4]
-    fcone[5] = -L * u0[k * force_size + 2] - u0[k * force_size + 4]
-
-    assert np.allclose(fdata.value, fcone)
-
     fun_fd = aligator.FiniteDifferenceHelper(space, fun, FD_EPS)
     fdata2 = fun_fd.createData()
     fun_fd.evaluate(x0, u0, x0, fdata2)


### PR DESCRIPTION
This PR aims at adding a new feature to the centroidal dynamics and costs formulation, namely the option to consider 6D contacts with angular forces. It also provides an approximated wrench cone residual with 4 facets. The 6D contact dynamics is especially useful for robots with large feet like Talos. 