### PR TITLE
Standardize CMake output directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added constrained LQR example
 
+### Changed
+- Standardized CMake output directories ([#147](https://github.com/Simple-Robotics/aligator/pull/147))
+
 ## [0.5.1] - 2024-04-24
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,14 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
                                                "RelWithDebInfo")
 endif()
 
+function(set_standard_output_directory target)
+  set_target_properties(
+    ${target}
+    PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/bin
+               LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+               ARCHIVE_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
+endfunction()
+
 # --- OPTIONS ----------------------------------------
 option(BUILD_PYTHON_INTERFACE "Build the Python bindings" ON)
 option(BUILD_WITH_VERSION_SUFFIX "Build libraries with version appended to suffix" OFF)
@@ -214,6 +222,7 @@ function(create_library)
     PROPERTIES LINKER_LANGUAGE CXX
                VERSION ${PROJECT_VERSION}
                INSTALL_RPATH "\$ORIGIN")
+  set_standard_output_directory(${PROJECT_NAME})
 
   # Extract the compile definitions of the project for export
   get_directory_property(CURRENT_COMPILE_DEFINITIONS COMPILE_DEFINITIONS)
@@ -270,6 +279,7 @@ macro(create_ex_or_bench exfile exname)
   add_executable(${exname} ${exfile})
   message(STATUS "Adding cpp example ${exname}")
   set_target_properties(${exname} PROPERTIES LINKER_LANGUAGE CXX)
+  set_standard_output_directory(${exname})
   target_include_directories(${exname} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
   target_link_libraries(${exname} PUBLIC ${PROJECT_NAME})
@@ -295,6 +305,7 @@ if(BUILD_CROCODDYL_COMPAT AND (BUILD_EXAMPLES OR BUILD_BENCHMARKS))
   target_include_directories(croc_talos_arm_utils PUBLIC ${CMAKE_SOURCE_DIR}/examples)
   target_link_libraries(croc_talos_arm_utils PUBLIC ${PROJECT_NAME} Boost::boost
                                                     crocoddyl::crocoddyl)
+  set_standard_output_directory(croc_talos_arm_utils)
   target_add_example_robot_data(croc_talos_arm_utils)
 endif()
 

--- a/src/compat/crocoddyl/CMakeLists.txt
+++ b/src/compat/crocoddyl/CMakeLists.txt
@@ -4,6 +4,7 @@ set(CROC_INSTALL_INCLUDE_DIR ${CMAKE_INSTALL_FULL_INCLUDEDIR}/${PROJECT_NAME}/co
 file(GLOB_RECURSE HEADERS ${INCLUDE_DIR}/*.hpp ${INCLUDE_DIR}/*.hxx)
 add_library(aligator_croc_compat SHARED ${HEADERS})
 add_library(aligator::croc_compat ALIAS aligator_croc_compat)
+set_standard_output_directory(aligator_croc_compat)
 
 if(ENABLE_TEMPLATE_INSTANTIATION)
   file(GLOB SOURCES_TEMPL ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
@@ -19,6 +20,7 @@ set_target_properties(
   PROPERTIES LINKER_LANGUAGE CXX
              LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}
              PUBLIC_HEADER "${HEADERS}"
+             INSTALL_RPATH "\$ORIGIN"
              VERSION ${PROJECT_VERSION})
 
 target_link_libraries(aligator_croc_compat PUBLIC ${PROJECT_NAME} crocoddyl::crocoddyl)

--- a/tests/python/CMakeLists.txt
+++ b/tests/python/CMakeLists.txt
@@ -36,6 +36,7 @@ function(add_test_binding_lib test_name)
   create_ctest_build_tests_target()
 
   add_library(${test_name} SHARED "${test_name}.cpp")
+  set_standard_output_directory(${test_name})
   target_link_libraries(${test_name} PUBLIC ${PYLIB_NAME})
   target_link_libraries(${test_name} PUBLIC eigenpy::eigenpy)
   set_target_properties(${test_name} PROPERTIES PREFIX "" SUFFIX ${PYTHON_EXT_SUFFIX})


### PR DESCRIPTION
+ libraries/archives go to lib/
+ runtimes go to bin/

Same thing as what was done on proxsuite-nlp