### PR TITLE
Add contact force and wrench cone costs for multibodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.6.0] - 2024-05-23
 
 ### Added
-
 - Added constrained LQR example ([#145](https://github.com/Simple-Robotics/aligator/pull/145))
 - Adds [tracy](https://github.com/Simple-Robotics/tracy) as a profiling tool
 - Adds a new sublibrary called `gar` to represent and solve time-varying linear-quadratic subproblems
@@ -22,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add SE2 car benchmark `bench/se2-car.cpp`
 - Split part of `macros.hpp` into new header `eigen-macros.hpp`, add `ALIGATOR_NOMALLOC_SCOPED` macro to disable Eigen's malloc per-scope and a caching system to restore the malloc status
 - Add `context.hpp` file for `aligator/modelling/dynamics`
+- Add force and wrench cone costs
+- Add centroidal momentum cost
 
 ### Changed
 

--- a/bindings/python/src/modelling/expose-center-of-mass.cpp
+++ b/bindings/python/src/modelling/expose-center-of-mass.cpp
@@ -5,6 +5,7 @@
 
 #include "aligator/modelling/multibody/center-of-mass-translation.hpp"
 #include "aligator/modelling/multibody/center-of-mass-velocity.hpp"
+#include "aligator/modelling/multibody/centroidal-momentum.hpp"
 #include "aligator/modelling/multibody/centroidal-momentum-derivative.hpp"
 #include "aligator/modelling/contact-map.hpp"
 
@@ -30,6 +31,9 @@ void exposeCenterOfMassFunctions() {
       CentroidalMomentumDerivativeResidualTpl<Scalar>;
   using CentroidalMomentumDerivativeData =
       CentroidalMomentumDerivativeDataTpl<Scalar>;
+
+  using CentroidalMomentumResidual = CentroidalMomentumResidualTpl<Scalar>;
+  using CentroidalMomentumData = CentroidalMomentumDataTpl<Scalar>;
 
   bp::class_<CenterOfMassTranslation, bp::bases<UnaryFunction>>(
       "CenterOfMassTranslationResidual",
@@ -90,9 +94,29 @@ void exposeCenterOfMassFunctions() {
   bp::register_ptr_to_python<shared_ptr<CentroidalMomentumDerivativeData>>();
 
   bp::class_<CentroidalMomentumDerivativeData, bp::bases<StageFunctionData>>(
-      "AngularMomentumConstraintResidualData",
-      "Data Structure for CentroidalMomentumResidual", bp::no_init)
+      "CentroidalMomentumDerivativeResidualData",
+      "Data Structure for CentroidalMomentumDerivativeResidual", bp::no_init)
       .def_readonly("pin_data", &CentroidalMomentumDerivativeData::pin_data_,
+                    "Pinocchio data struct.");
+
+  bp::class_<CentroidalMomentumResidual, bp::bases<UnaryFunction>>(
+      "CentroidalMomentumResidual", "A residual function :math:`r(x) = H` ",
+      bp::init<const int, const int, const PinModel &,
+               const context::Vector6s &>(
+          bp::args("self", "ndx", "nu", "model", "h_ref")))
+      .def(FrameAPIVisitor<CentroidalMomentumResidual>())
+      .def("getReference", &CentroidalMomentumResidual::getReference,
+           bp::args("self"), bp::return_internal_reference<>(),
+           "Get the centroidal target.")
+      .def("setReference", &CentroidalMomentumResidual::setReference,
+           bp::args("self", "h_new"), "Set the centroidal target.");
+
+  bp::register_ptr_to_python<shared_ptr<CentroidalMomentumData>>();
+
+  bp::class_<CentroidalMomentumData, bp::bases<StageFunctionData>>(
+      "CentroidalMomentumResidualData",
+      "Data Structure for CentroidalMomentumResidual", bp::no_init)
+      .def_readonly("pin_data", &CentroidalMomentumData::pin_data_,
                     "Pinocchio data struct.");
 }
 

--- a/bindings/python/src/modelling/expose-force-cost.cpp
+++ b/bindings/python/src/modelling/expose-force-cost.cpp
@@ -5,6 +5,7 @@
 #include "aligator/python/fwd.hpp"
 #include "aligator/python/modelling/multibody-utils.hpp"
 #include "aligator/modelling/multibody/contact-force.hpp"
+#include "aligator/modelling/multibody/multibody-wrench-cone.hpp"
 
 namespace aligator {
 namespace python {
@@ -29,6 +30,9 @@ void exposeContactForce() {
   using ContactForceResidual = ContactForceResidualTpl<Scalar>;
   using ContactForceData = ContactForceDataTpl<Scalar>;
 
+  using MultibodyWrenchConeResidual = MultibodyWrenchConeResidualTpl<Scalar>;
+  using MultibodyWrenchConeData = MultibodyWrenchConeDataTpl<Scalar>;
+
   bp::class_<ContactForceResidual, bp::bases<StageFunction>>(
       "ContactForceResidual",
       "A residual function :math:`r(x) = v_{j,xy} e^{-s z_j}` where :math:`j` "
@@ -49,6 +53,26 @@ void exposeContactForce() {
       .def_readwrite("tau", &ContactForceData::tau_)
       .def_readwrite("pin_data", &ContactForceData::pin_data_)
       .def_readwrite("constraint_datas", &ContactForceData::constraint_datas_);
+
+  bp::class_<MultibodyWrenchConeResidual, bp::bases<StageFunction>>(
+      "MultibodyWrenchConeResidual", "A residual function :math:`r(x) = Af` ",
+      bp::no_init)
+      .def(bp::init<int, PinModel, const context::MatrixXs &,
+                    const RigidConstraintModelVector &,
+                    const pinocchio::ProximalSettingsTpl<Scalar> &, const int,
+                    const double, const double, const double>(bp::args(
+          "self", "ndx", "model", "actuation_matrix", "constraint_models",
+          "prox_settings", "contact_id", "mu", "half_length", "half_width")))
+      .def(FrameAPIVisitor<MultibodyWrenchConeResidual>())
+      .def_readwrite("constraint_models",
+                     &MultibodyWrenchConeResidual::constraint_models_);
+
+  bp::class_<MultibodyWrenchConeData, bp::bases<StageFunctionData>>(
+      "MultibodyWrenchConeData", bp::no_init)
+      .def_readwrite("tau", &MultibodyWrenchConeData::tau_)
+      .def_readwrite("pin_data", &MultibodyWrenchConeData::pin_data_)
+      .def_readwrite("constraint_datas",
+                     &MultibodyWrenchConeData::constraint_datas_);
 }
 
 } // namespace python

--- a/bindings/python/src/modelling/expose-force-cost.cpp
+++ b/bindings/python/src/modelling/expose-force-cost.cpp
@@ -45,6 +45,11 @@ void exposeContactForce() {
           bp::args("self", "ndx", "model", "actuation_matrix",
                    "constraint_models", "prox_settings", "fref", "contact_id")))
       .def(FrameAPIVisitor<ContactForceResidual>())
+      .def("getReference", &ContactForceResidual::getReference,
+           bp::args("self"), bp::return_internal_reference<>(),
+           "Get the target force.")
+      .def("setReference", &ContactForceResidual::setReference,
+           bp::args("self", "fnew"), "Set the target force.")
       .def_readwrite("constraint_models",
                      &ContactForceResidual::constraint_models_);
 

--- a/bindings/python/src/modelling/expose-force-cost.cpp
+++ b/bindings/python/src/modelling/expose-force-cost.cpp
@@ -4,6 +4,8 @@
 
 #include "aligator/python/fwd.hpp"
 #include "aligator/python/modelling/multibody-utils.hpp"
+
+#ifdef ALIGATOR_PINOCCHIO_V3
 #include "aligator/modelling/multibody/contact-force.hpp"
 #include "aligator/modelling/multibody/multibody-wrench-cone.hpp"
 
@@ -82,5 +84,7 @@ void exposeContactForce() {
 
 } // namespace python
 } // namespace aligator
+
+#endif
 
 #endif

--- a/bindings/python/src/modelling/expose-force-cost.cpp
+++ b/bindings/python/src/modelling/expose-force-cost.cpp
@@ -1,0 +1,57 @@
+/// @file
+/// @copyright Copyright (C) 2023 LAAS-CNRS, INRIA
+#ifdef ALIGATOR_WITH_PINOCCHIO
+
+#include "aligator/python/fwd.hpp"
+#include "aligator/python/modelling/multibody-utils.hpp"
+#include "aligator/modelling/multibody/contact-force.hpp"
+
+namespace aligator {
+namespace python {
+
+using context::ConstVectorRef;
+using context::MultibodyPhaseSpace;
+using context::PinModel;
+using context::Scalar;
+using context::StageFunction;
+using context::StageFunctionData;
+using RigidConstraintModel =
+    pinocchio::RigidConstraintModelTpl<context::Scalar, 0>;
+using RigidConstraintData =
+    pinocchio::RigidConstraintDataTpl<context::Scalar, 0>;
+
+using RigidConstraintModelVector =
+    PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel);
+using RigidConstraintDataVector =
+    PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintData);
+
+void exposeContactForce() {
+  using ContactForceResidual = ContactForceResidualTpl<Scalar>;
+  using ContactForceData = ContactForceDataTpl<Scalar>;
+
+  bp::class_<ContactForceResidual, bp::bases<StageFunction>>(
+      "ContactForceResidual",
+      "A residual function :math:`r(x) = v_{j,xy} e^{-s z_j}` where :math:`j` "
+      "is a given frame index.",
+      bp::no_init)
+      .def(bp::init<int, PinModel, const context::MatrixXs &,
+                    const RigidConstraintModelVector &,
+                    const pinocchio::ProximalSettingsTpl<Scalar> &,
+                    const context::Vector6s &, int>(
+          bp::args("self", "ndx", "model", "actuation_matrix",
+                   "constraint_models", "prox_settings", "fref", "contact_id")))
+      .def(FrameAPIVisitor<ContactForceResidual>())
+      .def_readwrite("constraint_models",
+                     &ContactForceResidual::constraint_models_);
+
+  bp::class_<ContactForceData, bp::bases<StageFunctionData>>("ContactForceData",
+                                                             bp::no_init)
+      .def_readwrite("tau", &ContactForceData::tau_)
+      .def_readwrite("pin_data", &ContactForceData::pin_data_)
+      .def_readwrite("constraint_datas", &ContactForceData::constraint_datas_);
+}
+
+} // namespace python
+} // namespace aligator
+
+#endif

--- a/bindings/python/src/modelling/expose-pinocchio-functions.cpp
+++ b/bindings/python/src/modelling/expose-pinocchio-functions.cpp
@@ -20,6 +20,7 @@ using context::PinModel;
 
 // fwd declaration, see expose-fly-high.cpp
 void exposeFlyHigh();
+void exposeContactForce();
 void exposeCenterOfMassFunctions();
 
 void exposeFrameFunctions() {
@@ -126,6 +127,7 @@ auto underactuatedConstraintInvDyn_proxy(
 void exposePinocchioFunctions() {
   exposeFrameFunctions();
   exposeFlyHigh();
+  exposeContactForce();
   exposeCenterOfMassFunctions();
 
 #ifdef ALIGATOR_PINOCCHIO_V3

--- a/bindings/python/src/modelling/expose-pinocchio-functions.cpp
+++ b/bindings/python/src/modelling/expose-pinocchio-functions.cpp
@@ -20,9 +20,10 @@ using context::PinModel;
 
 // fwd declaration, see expose-fly-high.cpp
 void exposeFlyHigh();
+#ifdef ALIGATOR_PINOCCHIO_V3
 void exposeContactForce();
+#endif
 void exposeCenterOfMassFunctions();
-
 void exposeFrameFunctions() {
   using context::Manifold;
   using context::Scalar;
@@ -127,7 +128,9 @@ auto underactuatedConstraintInvDyn_proxy(
 void exposePinocchioFunctions() {
   exposeFrameFunctions();
   exposeFlyHigh();
+#ifdef ALIGATOR_PINOCCHIO_V3
   exposeContactForce();
+#endif
   exposeCenterOfMassFunctions();
 
 #ifdef ALIGATOR_PINOCCHIO_V3

--- a/examples/solo_kinodynamics.py
+++ b/examples/solo_kinodynamics.py
@@ -1,5 +1,6 @@
 import aligator
 import pinocchio as pin
+import pinocchio.visualize
 from utils.solo import robot, rmodel, rdata, q0
 import time
 

--- a/include/aligator/modelling/dynamics/kinodynamics-fwd.hpp
+++ b/include/aligator/modelling/dynamics/kinodynamics-fwd.hpp
@@ -3,6 +3,7 @@
 
 #include "aligator/modelling/dynamics/ode-abstract.hpp"
 
+#include <Eigen/src/LU/PartialPivLU.h>
 #include <proxsuite-nlp/modelling/spaces/multibody.hpp>
 #include <pinocchio/multibody/model.hpp>
 
@@ -70,6 +71,7 @@ template <typename Scalar> struct KinodynamicsFwdDataTpl : ODEDataTpl<Scalar> {
   using PinData = pinocchio::DataTpl<Scalar>;
   using VectorXs = typename math_types<Scalar>::VectorXs;
   using Matrix6Xs = typename math_types<Scalar>::Matrix6Xs;
+  using Matrix3Xs = typename math_types<Scalar>::Matrix3Xs;
   using Matrix3s = Eigen::Matrix<Scalar, 3, 3>;
   using Matrix6s = Eigen::Matrix<Scalar, 6, 6>;
   using Vector6s = Eigen::Matrix<Scalar, 6, 1>;
@@ -79,6 +81,8 @@ template <typename Scalar> struct KinodynamicsFwdDataTpl : ODEDataTpl<Scalar> {
   Matrix6Xs dhdot_dq_;
   Matrix6Xs dhdot_dv_;
   Matrix6Xs dhdot_da_;
+  Matrix6Xs temp1_;
+  Matrix3Xs temp2_;
   Matrix6Xs fJf_;
   VectorXs v0_;
   VectorXs a0_;
@@ -86,6 +90,7 @@ template <typename Scalar> struct KinodynamicsFwdDataTpl : ODEDataTpl<Scalar> {
   Vector6s cforces_;
   Matrix3s Jtemp_;
   Matrix6s Agu_inv_;
+  Eigen::PartialPivLU<Eigen::Matrix<Scalar, 6, 6>> PivLU_;
 
   KinodynamicsFwdDataTpl(const KinodynamicsFwdDynamicsTpl<Scalar> *model);
 };

--- a/include/aligator/modelling/multibody/centroidal-momentum-derivative.hpp
+++ b/include/aligator/modelling/multibody/centroidal-momentum-derivative.hpp
@@ -67,12 +67,14 @@ struct CentroidalMomentumDerivativeDataTpl : StageFunctionDataTpl<Scalar> {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   using Base = StageFunctionDataTpl<Scalar>;
   using PinData = pinocchio::DataTpl<Scalar>;
+  using Matrix3Xs = typename math_types<Scalar>::Matrix3Xs;
   using Matrix6Xs = typename math_types<Scalar>::Matrix6Xs;
   using Matrix3s = Eigen::Matrix<Scalar, 3, 3>;
 
   /// Pinocchio data object.
   PinData pin_data_;
   Matrix3s Jtemp_;
+  Matrix3Xs temp_;
   Matrix6Xs fJf_;
 
   CentroidalMomentumDerivativeDataTpl(

--- a/include/aligator/modelling/multibody/centroidal-momentum-derivative.hpp
+++ b/include/aligator/modelling/multibody/centroidal-momentum-derivative.hpp
@@ -54,7 +54,7 @@ public:
   void evaluate(const ConstVectorRef &x, const ConstVectorRef &u,
                 const ConstVectorRef &, BaseData &data) const;
 
-  void computeJacobians(const ConstVectorRef &c, const ConstVectorRef &u,
+  void computeJacobians(const ConstVectorRef &x, const ConstVectorRef &u,
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {

--- a/include/aligator/modelling/multibody/centroidal-momentum-derivative.hxx
+++ b/include/aligator/modelling/multibody/centroidal-momentum-derivative.hxx
@@ -73,8 +73,8 @@ void CentroidalMomentumDerivativeResidualTpl<Scalar>::computeJacobians(
       d.Jtemp_ << 0, -u[i_ * force_size_ + 2], u[i_ * force_size_ + 1],
           u[i_ * force_size_ + 2], 0, -u[i_ * force_size_],
           -u[i_ * force_size_ + 1], u[i_ * force_size_], 0;
-      d.Jx_.bottomLeftCorner(3, pin_model_.nv) +=
-          d.Jtemp_ * (pdata.Jcom - d.fJf_.template topRows<3>());
+      d.temp_.noalias() = pdata.Jcom - d.fJf_.template topRows<3>();
+      d.Jx_.bottomLeftCorner(3, pin_model_.nv).noalias() += d.Jtemp_ * d.temp_;
     }
   }
 
@@ -104,8 +104,10 @@ CentroidalMomentumDerivativeDataTpl<Scalar>::
     CentroidalMomentumDerivativeDataTpl(
         const CentroidalMomentumDerivativeResidualTpl<Scalar> *model)
     : Base(model->ndx1, model->nu, model->ndx2, 6),
-      pin_data_(model->pin_model_), fJf_(6, model->pin_model_.nv) {
+      pin_data_(model->pin_model_), temp_(3, model->pin_model_.nv),
+      fJf_(6, model->pin_model_.nv) {
   fJf_.setZero();
+  temp_.setZero();
 }
 
 } // namespace aligator

--- a/include/aligator/modelling/multibody/centroidal-momentum.hpp
+++ b/include/aligator/modelling/multibody/centroidal-momentum.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include "./fwd.hpp"
+#include "aligator/core/unary-function.hpp"
+
+#include <pinocchio/multibody/model.hpp>
+
+namespace aligator {
+
+template <typename Scalar> struct CentroidalMomentumDataTpl;
+
+/**
+ * @brief This residual returns the derivative of centroidal momentum
+ * for a kinodynamics model.
+ */
+
+template <typename _Scalar>
+struct CentroidalMomentumResidualTpl : UnaryFunctionTpl<_Scalar>, frame_api {
+public:
+  using Scalar = _Scalar;
+  ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
+  using Base = UnaryFunctionTpl<Scalar>;
+  using BaseData = typename Base::Data;
+  using Model = pinocchio::ModelTpl<Scalar>;
+  using SE3 = pinocchio::SE3Tpl<Scalar>;
+  using Data = CentroidalMomentumDataTpl<Scalar>;
+
+  Model pin_model_;
+  Vector6s h_ref_;
+
+  CentroidalMomentumResidualTpl(const int ndx, const int nu, const Model &model,
+                                const Vector6s &h_ref)
+      : Base(ndx, nu, 6), pin_model_(model), h_ref_(h_ref) {}
+
+  void evaluate(const ConstVectorRef &x, BaseData &data) const;
+
+  void computeJacobians(const ConstVectorRef &x, BaseData &data) const;
+
+  const Vector6s &getReference() const { return h_ref_; }
+  void setReference(const Eigen::Ref<const Vector6s> &h_new) { h_ref_ = h_new; }
+
+  shared_ptr<BaseData> createData() const {
+    return allocate_shared_eigen_aligned<Data>(this);
+  }
+};
+
+template <typename Scalar>
+struct CentroidalMomentumDataTpl : StageFunctionDataTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  using Base = StageFunctionDataTpl<Scalar>;
+  using PinData = pinocchio::DataTpl<Scalar>;
+  using Matrix6Xs = typename math_types<Scalar>::Matrix6Xs;
+
+  /// Pinocchio data object.
+  PinData pin_data_;
+  Matrix6Xs dh_dq_;
+  Matrix6Xs dhdot_dq_;
+  Matrix6Xs dhdot_dv_;
+  Matrix6Xs dhdot_da_;
+
+  CentroidalMomentumDataTpl(const CentroidalMomentumResidualTpl<Scalar> *model);
+};
+
+} // namespace aligator
+
+#include "aligator/modelling/multibody/centroidal-momentum.hxx"
+
+#ifdef ALIGATOR_ENABLE_TEMPLATE_INSTANTIATION
+#include "./centroidal-momentum.txx"
+#endif

--- a/include/aligator/modelling/multibody/centroidal-momentum.hxx
+++ b/include/aligator/modelling/multibody/centroidal-momentum.hxx
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "aligator/modelling/multibody/centroidal-momentum.hpp"
+
+#include <pinocchio/algorithm/centroidal-derivatives.hpp>
+#include <pinocchio/algorithm/centroidal.hpp>
+
+namespace aligator {
+
+template <typename Scalar>
+void CentroidalMomentumResidualTpl<Scalar>::evaluate(const ConstVectorRef &x,
+                                                     BaseData &data) const {
+  Data &d = static_cast<Data &>(data);
+  pinocchio::DataTpl<Scalar> &pdata = d.pin_data_;
+
+  const auto q = x.head(pin_model_.nq);
+  const auto v = x.tail(pin_model_.nv);
+
+  pinocchio::ccrba(pin_model_, pdata, q, v); // Compute Ag
+
+  d.value_ = pdata.Ag * v - h_ref_;
+}
+
+template <typename Scalar>
+void CentroidalMomentumResidualTpl<Scalar>::computeJacobians(
+    const ConstVectorRef &x, BaseData &data) const {
+  Data &d = static_cast<Data &>(data);
+  pinocchio::DataTpl<Scalar> &pdata = d.pin_data_;
+
+  const auto q = x.head(pin_model_.nq);
+  const auto v = x.tail(pin_model_.nv);
+
+  pinocchio::computeCentroidalDynamicsDerivatives(
+      pin_model_, pdata, q, v, Eigen::VectorXd::Zero(pin_model_.nv), d.dh_dq_,
+      d.dhdot_dq_, d.dhdot_dv_, d.dhdot_da_);
+
+  d.Jx_.leftCols(pin_model_.nv) = d.dh_dq_;
+  d.Jx_.rightCols(pin_model_.nv) = pdata.Ag;
+}
+
+template <typename Scalar>
+CentroidalMomentumDataTpl<Scalar>::CentroidalMomentumDataTpl(
+    const CentroidalMomentumResidualTpl<Scalar> *model)
+    : Base(model->ndx1, model->nu, model->ndx2, 6),
+      pin_data_(model->pin_model_), dh_dq_(6, model->pin_model_.nv),
+      dhdot_dq_(6, model->pin_model_.nv), dhdot_dv_(6, model->pin_model_.nv),
+      dhdot_da_(6, model->pin_model_.nv) {
+  dh_dq_.setZero();
+  dhdot_dq_.setZero();
+  dhdot_dv_.setZero();
+  dhdot_da_.setZero();
+}
+
+} // namespace aligator

--- a/include/aligator/modelling/multibody/centroidal-momentum.txx
+++ b/include/aligator/modelling/multibody/centroidal-momentum.txx
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "aligator/context.hpp"
+#include "aligator/modelling/multibody/centroidal-momentum.hpp"
+
+namespace aligator {
+
+extern template struct CentroidalMomentumResidualTpl<context::Scalar>;
+extern template struct CentroidalMomentumDataTpl<context::Scalar>;
+
+} // namespace aligator

--- a/include/aligator/modelling/multibody/contact-force.hpp
+++ b/include/aligator/modelling/multibody/contact-force.hpp
@@ -7,9 +7,9 @@
 #include <proxsuite-nlp/modelling/spaces/multibody.hpp>
 #include <pinocchio/multibody/data.hpp>
 
+#ifdef ALIGATOR_PINOCCHIO_V3
 #include <pinocchio/algorithm/proximal.hpp>
 
-#ifdef ALIGATOR_PINOCCHIO_V3
 namespace aligator {
 
 template <typename Scalar> struct ContactForceDataTpl;

--- a/include/aligator/modelling/multibody/contact-force.hpp
+++ b/include/aligator/modelling/multibody/contact-force.hpp
@@ -57,6 +57,9 @@ public:
     }
   }
 
+  const Vector6s &getReference() const { return fref_; }
+  void setReference(const Eigen::Ref<const Vector6s> &fnew) { fref_ = fnew; }
+
   void evaluate(const ConstVectorRef &x, const ConstVectorRef &u,
                 const ConstVectorRef &, BaseData &data) const;
 

--- a/include/aligator/modelling/multibody/contact-force.hpp
+++ b/include/aligator/modelling/multibody/contact-force.hpp
@@ -63,7 +63,7 @@ public:
   void evaluate(const ConstVectorRef &x, const ConstVectorRef &u,
                 const ConstVectorRef &, BaseData &data) const;
 
-  void computeJacobians(const ConstVectorRef &x, const ConstVectorRef &,
+  void computeJacobians(const ConstVectorRef &, const ConstVectorRef &,
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {

--- a/include/aligator/modelling/multibody/contact-force.hpp
+++ b/include/aligator/modelling/multibody/contact-force.hpp
@@ -9,6 +9,7 @@
 
 #include <pinocchio/algorithm/proximal.hpp>
 
+#ifdef ALIGATOR_PINOCCHIO_V3
 namespace aligator {
 
 template <typename Scalar> struct ContactForceDataTpl;
@@ -98,3 +99,5 @@ struct ContactForceDataTpl : StageFunctionDataTpl<Scalar> {
 #ifdef ALIGATOR_ENABLE_TEMPLATE_INSTANTIATION
 #include "./contact-force.txx"
 #endif
+
+#endif // ALIGATOR_PINOCCHIO_V3

--- a/include/aligator/modelling/multibody/contact-force.hpp
+++ b/include/aligator/modelling/multibody/contact-force.hpp
@@ -1,0 +1,97 @@
+#pragma once
+
+#include "./fwd.hpp"
+#include "aligator/core/function-abstract.hpp"
+
+#include <pinocchio/multibody/model.hpp>
+#include <proxsuite-nlp/modelling/spaces/multibody.hpp>
+#include <pinocchio/multibody/data.hpp>
+
+#include <pinocchio/algorithm/proximal.hpp>
+
+namespace aligator {
+
+template <typename Scalar> struct ContactForceDataTpl;
+
+/**
+ * @brief This residual returns the derivative of centroidal momentum
+ * for a kinodynamics model.
+ */
+
+template <typename _Scalar>
+struct ContactForceResidualTpl : StageFunctionTpl<_Scalar>, frame_api {
+public:
+  using Scalar = _Scalar;
+  ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
+  using Base = StageFunctionTpl<Scalar>;
+  using BaseData = typename Base::Data;
+  using Model = pinocchio::ModelTpl<Scalar>;
+  using SE3 = pinocchio::SE3Tpl<Scalar>;
+  using Data = ContactForceDataTpl<Scalar>;
+  using RigidConstraintModelVector = PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(
+      pinocchio::RigidConstraintModel);
+  using RigidConstraintDataVector =
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(pinocchio::RigidConstraintData);
+  using ProxSettings = pinocchio::ProximalSettingsTpl<Scalar>;
+
+  Model pin_model_;
+  MatrixXs actuation_matrix_;
+  RigidConstraintModelVector constraint_models_;
+  ProxSettings prox_settings_;
+  Vector6s fref_;
+  int contact_id_;
+
+  ContactForceResidualTpl(const int ndx, const Model &model,
+                          const MatrixXs &actuation,
+                          const RigidConstraintModelVector &constraint_models,
+                          const ProxSettings &prox_settings,
+                          const Vector6s &fref, const int contact_id)
+      : Base(ndx, (int)actuation.cols(), 6), pin_model_(model),
+        actuation_matrix_(actuation), constraint_models_(constraint_models),
+        prox_settings_(prox_settings), fref_(fref), contact_id_(contact_id) {
+    if (model.nv != actuation.rows()) {
+      ALIGATOR_DOMAIN_ERROR(
+          fmt::format("actuation matrix should have number of rows = pinocchio "
+                      "model nv ({} and {}).",
+                      actuation.rows(), model.nv));
+    }
+  }
+
+  void evaluate(const ConstVectorRef &x, const ConstVectorRef &u,
+                const ConstVectorRef &, BaseData &data) const;
+
+  void computeJacobians(const ConstVectorRef &x, const ConstVectorRef &,
+                        const ConstVectorRef &, BaseData &data) const;
+
+  shared_ptr<BaseData> createData() const {
+    return allocate_shared_eigen_aligned<Data>(this);
+  }
+};
+
+template <typename Scalar>
+struct ContactForceDataTpl : StageFunctionDataTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  using Base = StageFunctionDataTpl<Scalar>;
+  using PinData = pinocchio::DataTpl<Scalar>;
+  using VectorXs = typename math_types<Scalar>::VectorXs;
+  using MatrixXs = typename math_types<Scalar>::MatrixXs;
+  using RigidConstraintDataVector =
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(pinocchio::RigidConstraintData);
+
+  /// Pinocchio data object.
+  PinData pin_data_;
+  VectorXs tau_;
+
+  RigidConstraintDataVector constraint_datas_;
+  pinocchio::ProximalSettingsTpl<Scalar> settings;
+
+  ContactForceDataTpl(const ContactForceResidualTpl<Scalar> *model);
+};
+
+} // namespace aligator
+
+#include "aligator/modelling/multibody/contact-force.hxx"
+
+#ifdef ALIGATOR_ENABLE_TEMPLATE_INSTANTIATION
+#include "./contact-force.txx"
+#endif

--- a/include/aligator/modelling/multibody/contact-force.hxx
+++ b/include/aligator/modelling/multibody/contact-force.hxx
@@ -33,8 +33,6 @@ void ContactForceResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &x,
   Data &d = static_cast<Data &>(data);
   pinocchio::DataTpl<Scalar> &pdata = d.pin_data_;
 
-  const auto q = x.head(pin_model_.nq);
-
   pinocchio::computeConstraintDynamicsDerivatives(
       pin_model_, d.pin_data_, constraint_models_, d.constraint_datas_,
       d.settings);

--- a/include/aligator/modelling/multibody/contact-force.hxx
+++ b/include/aligator/modelling/multibody/contact-force.hxx
@@ -26,7 +26,7 @@ void ContactForceResidualTpl<Scalar>::evaluate(const ConstVectorRef &x,
 }
 
 template <typename Scalar>
-void ContactForceResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &x,
+void ContactForceResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &,
                                                        const ConstVectorRef &,
                                                        const ConstVectorRef &,
                                                        BaseData &data) const {

--- a/include/aligator/modelling/multibody/contact-force.hxx
+++ b/include/aligator/modelling/multibody/contact-force.hxx
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "aligator/modelling/multibody/contact-force.hpp"
+
+#include <pinocchio/algorithm/constrained-dynamics.hpp>
+#include <pinocchio/algorithm/constrained-dynamics-derivatives.hpp>
+#include <iostream>
+
+namespace aligator {
+
+template <typename Scalar>
+void ContactForceResidualTpl<Scalar>::evaluate(const ConstVectorRef &x,
+                                               const ConstVectorRef &u,
+                                               const ConstVectorRef &,
+                                               BaseData &data) const {
+  Data &d = static_cast<Data &>(data);
+  pinocchio::DataTpl<Scalar> &pdata = d.pin_data_;
+
+  const auto q = x.head(pin_model_.nq);
+  const auto v = x.tail(pin_model_.nv);
+
+  d.tau_ = actuation_matrix_ * u;
+  pinocchio::constraintDynamics(pin_model_, d.pin_data_, q, v, d.tau_,
+                                constraint_models_, d.constraint_datas_,
+                                d.settings);
+  d.value_ = d.pin_data_.lambda_c.segment(
+      contact_id_ * 6,
+      6); // d.pin_data_.lambda_c.segment(contact_id_ * 6, 6) - fref_;
+}
+
+template <typename Scalar>
+void ContactForceResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &x,
+                                                       const ConstVectorRef &,
+                                                       const ConstVectorRef &,
+                                                       BaseData &data) const {
+  Data &d = static_cast<Data &>(data);
+  pinocchio::DataTpl<Scalar> &pdata = d.pin_data_;
+
+  const auto q = x.head(pin_model_.nq);
+
+  pinocchio::computeConstraintDynamicsDerivatives(
+      pin_model_, d.pin_data_, constraint_models_, d.constraint_datas_,
+      d.settings);
+
+  d.Jx_.leftCols(pin_model_.nv) =
+      d.pin_data_.dlambda_dq.block(contact_id_ * 6, 0, 6, pin_model_.nv);
+  d.Jx_.rightCols(pin_model_.nv) =
+      d.pin_data_.dlambda_dv.block(contact_id_ * 6, 0, 6, pin_model_.nv);
+  d.Ju_ = d.pin_data_.dlambda_dtau.block(contact_id_ * 6, 0, 6, pin_model_.nv) *
+          actuation_matrix_;
+}
+
+template <typename Scalar>
+ContactForceDataTpl<Scalar>::ContactForceDataTpl(
+    const ContactForceResidualTpl<Scalar> *model)
+    : Base(model->ndx1, model->nu, model->ndx2, 6),
+      pin_data_(model->pin_model_), tau_(model->pin_model_.nv) {
+  tau_.setZero();
+
+  pinocchio::initConstraintDynamics(model->pin_model_, pin_data_,
+                                    model->constraint_models_);
+  for (auto cm = std::begin(model->constraint_models_);
+       cm != std::end(model->constraint_models_); ++cm) {
+    constraint_datas_.push_back(
+        pinocchio::RigidConstraintDataTpl<Scalar, 0>(*cm));
+  }
+}
+
+} // namespace aligator

--- a/include/aligator/modelling/multibody/contact-force.hxx
+++ b/include/aligator/modelling/multibody/contact-force.hxx
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "aligator/macros.hpp"
 #include "aligator/modelling/multibody/contact-force.hpp"
 
 #include <pinocchio/algorithm/constrained-dynamics.hpp>
 #include <pinocchio/algorithm/constrained-dynamics-derivatives.hpp>
+#include <aligator/macros.hpp>
 
 namespace aligator {
 
@@ -18,7 +20,7 @@ void ContactForceResidualTpl<Scalar>::evaluate(const ConstVectorRef &x,
   const auto q = x.head(pin_model_.nq);
   const auto v = x.tail(pin_model_.nv);
 
-  d.tau_ = actuation_matrix_ * u;
+  d.tau_.noalias() = actuation_matrix_ * u;
   pinocchio::constraintDynamics(pin_model_, d.pin_data_, q, v, d.tau_,
                                 constraint_models_, d.constraint_datas_,
                                 d.settings);
@@ -36,13 +38,13 @@ void ContactForceResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &,
   pinocchio::computeConstraintDynamicsDerivatives(
       pin_model_, d.pin_data_, constraint_models_, d.constraint_datas_,
       d.settings);
-
   d.Jx_.leftCols(pin_model_.nv) =
       d.pin_data_.dlambda_dq.block(contact_id_ * 6, 0, 6, pin_model_.nv);
   d.Jx_.rightCols(pin_model_.nv) =
       d.pin_data_.dlambda_dv.block(contact_id_ * 6, 0, 6, pin_model_.nv);
-  d.Ju_ = d.pin_data_.dlambda_dtau.block(contact_id_ * 6, 0, 6, pin_model_.nv) *
-          actuation_matrix_;
+  d.Ju_.noalias() =
+      d.pin_data_.dlambda_dtau.block(contact_id_ * 6, 0, 6, pin_model_.nv) *
+      actuation_matrix_;
 }
 
 template <typename Scalar>

--- a/include/aligator/modelling/multibody/contact-force.txx
+++ b/include/aligator/modelling/multibody/contact-force.txx
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "aligator/context.hpp"
+#include "aligator/modelling/multibody/contact-force.hpp"
+
+namespace aligator {
+
+extern template struct ContactForceResidualTpl<context::Scalar>;
+extern template struct ContactForceDataTpl<context::Scalar>;
+
+} // namespace aligator

--- a/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
+++ b/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
@@ -7,9 +7,9 @@
 #include <proxsuite-nlp/modelling/spaces/multibody.hpp>
 #include <pinocchio/multibody/data.hpp>
 
+#ifdef ALIGATOR_PINOCCHIO_V3
 #include <pinocchio/algorithm/proximal.hpp>
 
-#ifdef ALIGATOR_PINOCCHIO_V3
 namespace aligator {
 
 template <typename Scalar> struct MultibodyWrenchConeDataTpl;

--- a/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
+++ b/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
@@ -9,6 +9,7 @@
 
 #include <pinocchio/algorithm/proximal.hpp>
 
+#ifdef ALIGATOR_PINOCCHIO_V3
 namespace aligator {
 
 template <typename Scalar> struct MultibodyWrenchConeDataTpl;
@@ -109,3 +110,5 @@ struct MultibodyWrenchConeDataTpl : StageFunctionDataTpl<Scalar> {
 #ifdef ALIGATOR_ENABLE_TEMPLATE_INSTANTIATION
 #include "./multibody-wrench-cone.txx"
 #endif
+
+#endif // ALIGATOR_PINOCCHIO_V3

--- a/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
+++ b/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
@@ -73,7 +73,7 @@ public:
   void evaluate(const ConstVectorRef &x, const ConstVectorRef &u,
                 const ConstVectorRef &, BaseData &data) const;
 
-  void computeJacobians(const ConstVectorRef &x, const ConstVectorRef &,
+  void computeJacobians(const ConstVectorRef &, const ConstVectorRef &,
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {

--- a/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
+++ b/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
@@ -89,12 +89,14 @@ struct MultibodyWrenchConeDataTpl : StageFunctionDataTpl<Scalar> {
   using PinData = pinocchio::DataTpl<Scalar>;
   using VectorXs = typename math_types<Scalar>::VectorXs;
   using MatrixXs = typename math_types<Scalar>::MatrixXs;
+  using Matrix6Xs = typename math_types<Scalar>::Matrix6Xs;
   using RigidConstraintDataVector =
       PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(pinocchio::RigidConstraintData);
 
   /// Pinocchio data object.
   PinData pin_data_;
   VectorXs tau_;
+  Matrix6Xs temp_;
 
   RigidConstraintDataVector constraint_datas_;
   pinocchio::ProximalSettingsTpl<Scalar> settings;

--- a/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
+++ b/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "./fwd.hpp"
+#include "aligator/core/function-abstract.hpp"
+
+#include <pinocchio/multibody/model.hpp>
+#include <proxsuite-nlp/modelling/spaces/multibody.hpp>
+#include <pinocchio/multibody/data.hpp>
+
+#include <pinocchio/algorithm/proximal.hpp>
+
+namespace aligator {
+
+template <typename Scalar> struct MultibodyWrenchConeDataTpl;
+
+/**
+ * @brief This residual returns the derivative of centroidal momentum
+ * for a kinodynamics model.
+ */
+
+template <typename _Scalar>
+struct MultibodyWrenchConeResidualTpl : StageFunctionTpl<_Scalar>, frame_api {
+public:
+  using Scalar = _Scalar;
+  ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
+  using Base = StageFunctionTpl<Scalar>;
+  using BaseData = typename Base::Data;
+  using Model = pinocchio::ModelTpl<Scalar>;
+  using SE3 = pinocchio::SE3Tpl<Scalar>;
+  using Data = MultibodyWrenchConeDataTpl<Scalar>;
+  using RigidConstraintModelVector = PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(
+      pinocchio::RigidConstraintModel);
+  using RigidConstraintDataVector =
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(pinocchio::RigidConstraintData);
+  using ProxSettings = pinocchio::ProximalSettingsTpl<Scalar>;
+
+  Model pin_model_;
+  MatrixXs actuation_matrix_;
+  RigidConstraintModelVector constraint_models_;
+  ProxSettings prox_settings_;
+  double mu_;
+  double hL_;
+  double hW_;
+  int contact_id_;
+  Eigen::Matrix<Scalar, 17, 6> Acone_;
+
+  MultibodyWrenchConeResidualTpl(
+      const int ndx, const Model &model, const MatrixXs &actuation,
+      const RigidConstraintModelVector &constraint_models,
+      const ProxSettings &prox_settings, const int contact_id, const double mu,
+      const double half_length, const double half_width)
+      : Base(ndx, (int)actuation.cols(), 17), pin_model_(model),
+        actuation_matrix_(actuation), constraint_models_(constraint_models),
+        prox_settings_(prox_settings), mu_(mu), hL_(half_length),
+        hW_(half_width), contact_id_(contact_id) {
+    if (model.nv != actuation.rows()) {
+      ALIGATOR_DOMAIN_ERROR(
+          fmt::format("actuation matrix should have number of rows = pinocchio "
+                      "model nv ({} and {}).",
+                      actuation.rows(), model.nv));
+    }
+    Acone_ << 0, 0, -1, 0, 0, 0, -1, 0, -mu_, 0, 0, 0, 1, 0, -mu_, 0, 0, 0, 0,
+        -1, -mu_, 0, 0, 0, 0, 1, -mu_, 0, 0, 0, 0, 0, -hW_, -1, 0, 0, 0, 0,
+        -hW_, 1, 0, 0, 0, 0, -hL_, 0, -1, 0, 0, 0, -hL_, 0, 1, 0, -hW_, -hL_,
+        -(hL_ + hW_) * mu_, mu_, mu_, -1, -hW_, hL_, -(hL_ + hW_) * mu_, mu_,
+        -mu_, -1, hW_, -hL_, -(hL_ + hW_) * mu_, -mu_, mu_, -1, hW_, hL_,
+        -(hL_ + hW_) * mu_, -mu_, -mu_, -1, hW_, hL_, -(hL_ + hW_) * mu_, mu_,
+        mu_, 1, hW_, -hL_, -(hL_ + hW_) * mu_, mu_, -mu_, 1, -hW_, hL_,
+        -(hL_ + hW_) * mu_, -mu_, mu_, 1, -hW_, -hL_, -(hL_ + hW_) * mu_, -mu_,
+        -mu_, 1;
+  }
+
+  void evaluate(const ConstVectorRef &x, const ConstVectorRef &u,
+                const ConstVectorRef &, BaseData &data) const;
+
+  void computeJacobians(const ConstVectorRef &x, const ConstVectorRef &,
+                        const ConstVectorRef &, BaseData &data) const;
+
+  shared_ptr<BaseData> createData() const {
+    return allocate_shared_eigen_aligned<Data>(this);
+  }
+};
+
+template <typename Scalar>
+struct MultibodyWrenchConeDataTpl : StageFunctionDataTpl<Scalar> {
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+  using Base = StageFunctionDataTpl<Scalar>;
+  using PinData = pinocchio::DataTpl<Scalar>;
+  using VectorXs = typename math_types<Scalar>::VectorXs;
+  using MatrixXs = typename math_types<Scalar>::MatrixXs;
+  using RigidConstraintDataVector =
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(pinocchio::RigidConstraintData);
+
+  /// Pinocchio data object.
+  PinData pin_data_;
+  VectorXs tau_;
+
+  RigidConstraintDataVector constraint_datas_;
+  pinocchio::ProximalSettingsTpl<Scalar> settings;
+
+  MultibodyWrenchConeDataTpl(
+      const MultibodyWrenchConeResidualTpl<Scalar> *model);
+};
+
+} // namespace aligator
+
+#include "aligator/modelling/multibody/multibody-wrench-cone.hxx"
+
+#ifdef ALIGATOR_ENABLE_TEMPLATE_INSTANTIATION
+#include "./multibody-wrench-cone.txx"
+#endif

--- a/include/aligator/modelling/multibody/multibody-wrench-cone.hxx
+++ b/include/aligator/modelling/multibody/multibody-wrench-cone.hxx
@@ -29,11 +29,9 @@ void MultibodyWrenchConeResidualTpl<Scalar>::evaluate(const ConstVectorRef &x,
 
 template <typename Scalar>
 void MultibodyWrenchConeResidualTpl<Scalar>::computeJacobians(
-    const ConstVectorRef &x, const ConstVectorRef &, const ConstVectorRef &,
+    const ConstVectorRef &, const ConstVectorRef &, const ConstVectorRef &,
     BaseData &data) const {
   Data &d = static_cast<Data &>(data);
-
-  const auto q = x.head(pin_model_.nq);
 
   pinocchio::computeConstraintDynamicsDerivatives(
       pin_model_, d.pin_data_, constraint_models_, d.constraint_datas_,

--- a/include/aligator/modelling/multibody/multibody-wrench-cone.txx
+++ b/include/aligator/modelling/multibody/multibody-wrench-cone.txx
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "aligator/context.hpp"
+#include "aligator/modelling/multibody/multibody-wrench-cone.hpp"
+
+namespace aligator {
+
+extern template struct MultibodyWrenchConeResidualTpl<context::Scalar>;
+extern template struct MultibodyWrenchConeDataTpl<context::Scalar>;
+
+} // namespace aligator

--- a/src/modelling/multibody/centroidal-momentum.cpp
+++ b/src/modelling/multibody/centroidal-momentum.cpp
@@ -1,0 +1,8 @@
+#include "aligator/modelling/multibody/centroidal-momentum.hpp"
+
+namespace aligator {
+
+template struct CentroidalMomentumResidualTpl<context::Scalar>;
+template struct CentroidalMomentumDataTpl<context::Scalar>;
+
+} // namespace aligator

--- a/src/modelling/multibody/contact-force.cpp
+++ b/src/modelling/multibody/contact-force.cpp
@@ -1,0 +1,8 @@
+#include "aligator/modelling/multibody/contact-force.hpp"
+
+namespace aligator {
+
+template struct ContactForceResidualTpl<context::Scalar>;
+template struct ContactForceDataTpl<context::Scalar>;
+
+} // namespace aligator

--- a/src/modelling/multibody/contact-force.cpp
+++ b/src/modelling/multibody/contact-force.cpp
@@ -1,8 +1,10 @@
 #include "aligator/modelling/multibody/contact-force.hpp"
-
+#ifdef ALIGATOR_PINOCCHIO_V3
 namespace aligator {
 
 template struct ContactForceResidualTpl<context::Scalar>;
 template struct ContactForceDataTpl<context::Scalar>;
 
 } // namespace aligator
+
+#endif

--- a/src/modelling/multibody/multibody-wrench-cone.cpp
+++ b/src/modelling/multibody/multibody-wrench-cone.cpp
@@ -1,8 +1,10 @@
 #include "aligator/modelling/multibody/multibody-wrench-cone.hpp"
-
+#ifdef ALIGATOR_PINOCCHIO_V3
 namespace aligator {
 
 template struct MultibodyWrenchConeResidualTpl<context::Scalar>;
 template struct MultibodyWrenchConeDataTpl<context::Scalar>;
 
 } // namespace aligator
+
+#endif

--- a/src/modelling/multibody/multibody-wrench-cone.cpp
+++ b/src/modelling/multibody/multibody-wrench-cone.cpp
@@ -1,0 +1,8 @@
+#include "aligator/modelling/multibody/multibody-wrench-cone.hpp"
+
+namespace aligator {
+
+template struct MultibodyWrenchConeResidualTpl<context::Scalar>;
+template struct MultibodyWrenchConeDataTpl<context::Scalar>;
+
+} // namespace aligator

--- a/tests/forces.cpp
+++ b/tests/forces.cpp
@@ -1,0 +1,123 @@
+#include <pinocchio/parsers/sample-models.hpp>
+#include "aligator/core/function-abstract.hpp"
+#include "pinocchio/algorithm/kinematics.hpp"
+#include "pinocchio/algorithm/joint-configuration.hpp"
+#include <proxsuite-nlp/modelling/spaces/multibody.hpp>
+
+#include <boost/test/unit_test.hpp>
+#include <iostream>
+#include <aligator/modelling/multibody/contact-force.hpp>
+
+BOOST_AUTO_TEST_SUITE(forces)
+
+BOOST_AUTO_TEST_CASE(create_data) {
+  using namespace Eigen;
+  using namespace pinocchio;
+  using namespace aligator;
+
+  using ContactForceData = aligator::ContactForceDataTpl<double>;
+  using ContactForceResidual = aligator::ContactForceResidualTpl<double>;
+  using StageFunctionData = aligator::StageFunctionDataTpl<double>;
+  using Manifold = proxsuite::nlp::MultibodyPhaseSpace<double>;
+
+  Model model;
+  buildModels::humanoidRandom(model, true);
+  Data data(model), data_fd(model);
+
+  VectorXd q = randomConfiguration(model);
+  VectorXd v = VectorXd::Random(model.nv);
+  VectorXd x0(model.nv * 2 + 1);
+  x0 << q, v;
+  VectorXd u0 = VectorXd::Random(model.nv - 6);
+
+  const std::string LF = "lleg6_joint";
+  const Model::JointIndex LF_id = model.getJointId(LF);
+  const std::string RF = "rleg6_joint";
+  const Model::JointIndex RF_id = model.getJointId(RF);
+
+  // Contact models and data
+  PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)
+  constraint_models;
+  PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintData)
+  constraint_data;
+
+  RigidConstraintModel ci_LF(CONTACT_6D, model, LF_id, LOCAL);
+  ci_LF.joint1_placement.setRandom();
+  ci_LF.corrector.Kp.array() = 10;
+  ci_LF.corrector.Kd.array() = 10;
+
+  RigidConstraintModel ci_RF(CONTACT_6D, model, RF_id, LOCAL);
+  ci_RF.joint1_placement.setRandom();
+  ci_RF.corrector.Kp.array() = 10;
+  ci_RF.corrector.Kd.array() = 10;
+
+  constraint_models.push_back(ci_LF);
+  constraint_data.push_back(RigidConstraintData(ci_LF));
+  constraint_models.push_back(ci_RF);
+  constraint_data.push_back(RigidConstraintData(ci_RF));
+
+  Eigen::DenseIndex constraint_dim = 0;
+  for (size_t k = 0; k < constraint_models.size(); ++k)
+    constraint_dim += constraint_models[k].size();
+
+  const double mu0 = 0.;
+  ProximalSettings prox_settings(1e-12, mu0, 1);
+
+  shared_ptr<Manifold> space = std::make_shared<Manifold>(model);
+  MatrixXd act_matrix(model.nv, model.nv - 6);
+  act_matrix.setZero();
+  act_matrix.bottomRows(model.nv - 6).setIdentity();
+  VectorXd fref(6);
+  fref.setZero();
+  ContactForceResidual fun =
+      ContactForceResidual(space->ndx(), model, act_matrix, constraint_models,
+                           prox_settings, fref, 1);
+  shared_ptr<StageFunctionData> sfdata = fun.createData();
+  shared_ptr<ContactForceData> fdata =
+      std::static_pointer_cast<ContactForceData>(sfdata);
+
+  forwardKinematics(model, fdata->pin_data_, q);
+  updateFramePlacements(model, data);
+  fun.evaluate(x0, u0, x0, *fdata);
+  fun.computeJacobians(x0, u0, x0, *fdata);
+
+  MatrixXd lambda_partial_dx(6, model.nv * 2);
+  MatrixXd lambda_partial_du(6, model.nv - 6);
+  lambda_partial_dx = fdata->Jx_;
+  lambda_partial_du = fdata->Ju_;
+
+  // Data_fd
+  MatrixXd lambda_partial_dx_fd(6, model.nv * 2);
+  lambda_partial_dx_fd.setZero();
+  MatrixXd lambda_partial_du_fd(6, model.nv - 6);
+  lambda_partial_du_fd.setZero();
+
+  const VectorXd lambda0 = fdata->value_;
+  VectorXd v_eps(VectorXd::Zero(model.nv * 2));
+  VectorXd u_eps(VectorXd::Zero(model.nv - 6));
+  VectorXd x_plus(model.nq + model.nv);
+  VectorXd u_plus(model.nv - 6);
+
+  const double alpha = 1e-8;
+
+  for (int k = 0; k < model.nv * 2; ++k) {
+    v_eps[k] += alpha;
+    x_plus = space->integrate(x0, v_eps);
+    fun.evaluate(x_plus, u0, x_plus, *fdata);
+    lambda_partial_dx_fd.col(k) = (fdata->value_ - lambda0) / alpha;
+    v_eps[k] = 0.;
+  }
+
+  for (int k = 0; k < model.nv - 6; ++k) {
+    u_eps[k] += alpha;
+    u_plus = u0 + u_eps;
+    fun.evaluate(x0, u_plus, x0, *fdata);
+    lambda_partial_du_fd.col(k) = (fdata->value_ - lambda0) / alpha;
+    u_eps[k] = 0.;
+  }
+  // std::cout << sqrt(alpha) << std::endl;
+  BOOST_CHECK(lambda_partial_dx_fd.isApprox(lambda_partial_dx, sqrt(alpha)));
+  BOOST_CHECK(lambda_partial_du_fd.isApprox(lambda_partial_du, sqrt(alpha)));
+}
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/forces.cpp
+++ b/tests/forces.cpp
@@ -7,10 +7,11 @@
 #include <boost/test/unit_test.hpp>
 #include <iostream>
 #include <aligator/modelling/multibody/contact-force.hpp>
+#include <aligator/modelling/multibody/multibody-wrench-cone.hpp>
 
 BOOST_AUTO_TEST_SUITE(forces)
 
-BOOST_AUTO_TEST_CASE(create_data) {
+BOOST_AUTO_TEST_CASE(contact_forces) {
   using namespace Eigen;
   using namespace pinocchio;
   using namespace aligator;
@@ -118,6 +119,115 @@ BOOST_AUTO_TEST_CASE(create_data) {
   // std::cout << sqrt(alpha) << std::endl;
   BOOST_CHECK(lambda_partial_dx_fd.isApprox(lambda_partial_dx, sqrt(alpha)));
   BOOST_CHECK(lambda_partial_du_fd.isApprox(lambda_partial_du, sqrt(alpha)));
+}
+
+BOOST_AUTO_TEST_CASE(wrench_cone) {
+  using namespace Eigen;
+  using namespace pinocchio;
+  using namespace aligator;
+
+  using MultibodyWrenchConeData = aligator::MultibodyWrenchConeDataTpl<double>;
+  using MultibodyWrenchConeResidual =
+      aligator::MultibodyWrenchConeResidualTpl<double>;
+  using StageFunctionData = aligator::StageFunctionDataTpl<double>;
+  using Manifold = proxsuite::nlp::MultibodyPhaseSpace<double>;
+
+  Model model;
+  buildModels::humanoidRandom(model, true);
+  Data data(model), data_fd(model);
+
+  VectorXd q = randomConfiguration(model);
+  VectorXd v = VectorXd::Random(model.nv);
+  VectorXd x0(model.nv * 2 + 1);
+  x0 << q, v;
+  VectorXd u0 = VectorXd::Random(model.nv - 6);
+
+  const std::string LF = "lleg6_joint";
+  const Model::JointIndex LF_id = model.getJointId(LF);
+  const std::string RF = "rleg6_joint";
+  const Model::JointIndex RF_id = model.getJointId(RF);
+
+  // Contact models and data
+  PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)
+  constraint_models;
+  PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintData)
+  constraint_data;
+
+  RigidConstraintModel ci_LF(CONTACT_6D, model, LF_id, LOCAL);
+  ci_LF.joint1_placement.setRandom();
+  ci_LF.corrector.Kp.array() = 10;
+  ci_LF.corrector.Kd.array() = 10;
+
+  RigidConstraintModel ci_RF(CONTACT_6D, model, RF_id, LOCAL);
+  ci_RF.joint1_placement.setRandom();
+  ci_RF.corrector.Kp.array() = 10;
+  ci_RF.corrector.Kd.array() = 10;
+
+  constraint_models.push_back(ci_LF);
+  constraint_data.push_back(RigidConstraintData(ci_LF));
+  // constraint_models.push_back(ci_RF);
+  // constraint_data.push_back(RigidConstraintData(ci_RF));
+
+  const double mu0 = 0.;
+  ProximalSettings prox_settings(1e-12, mu0, 1);
+
+  shared_ptr<Manifold> space = std::make_shared<Manifold>(model);
+  MatrixXd act_matrix(model.nv, model.nv - 6);
+  act_matrix.setZero();
+  act_matrix.bottomRows(model.nv - 6).setIdentity();
+
+  double mu = 0.1;
+  double hL = 0.2;
+  double hW = 0.2;
+  MultibodyWrenchConeResidual fun = MultibodyWrenchConeResidual(
+      space->ndx(), model, act_matrix, constraint_models, prox_settings, 0, mu,
+      hL, hW);
+  shared_ptr<StageFunctionData> sfdata = fun.createData();
+  shared_ptr<MultibodyWrenchConeData> fdata =
+      std::static_pointer_cast<MultibodyWrenchConeData>(sfdata);
+
+  forwardKinematics(model, fdata->pin_data_, q);
+  updateFramePlacements(model, data);
+  fun.evaluate(x0, u0, x0, *fdata);
+  fun.computeJacobians(x0, u0, x0, *fdata);
+
+  MatrixXd cone_partial_dx(17, model.nv * 2);
+  MatrixXd cone_partial_du(17, model.nv - 6);
+  cone_partial_dx = fdata->Jx_;
+  cone_partial_du = fdata->Ju_;
+
+  // Data_fd
+  MatrixXd cone_partial_dx_fd(6, model.nv * 2);
+  cone_partial_dx_fd.setZero();
+  MatrixXd cone_partial_du_fd(6, model.nv - 6);
+  cone_partial_du_fd.setZero();
+
+  const VectorXd cone0 = fdata->value_;
+  VectorXd v_eps(VectorXd::Zero(model.nv * 2));
+  VectorXd u_eps(VectorXd::Zero(model.nv - 6));
+  VectorXd x_plus(model.nq + model.nv);
+  VectorXd u_plus(model.nv - 6);
+
+  const double alpha = 1e-8;
+
+  for (int k = 0; k < model.nv * 2; ++k) {
+    v_eps[k] += alpha;
+    x_plus = space->integrate(x0, v_eps);
+    fun.evaluate(x_plus, u0, x_plus, *fdata);
+    cone_partial_dx_fd.col(k) = (fdata->value_ - cone0) / alpha;
+    v_eps[k] = 0.;
+  }
+
+  for (int k = 0; k < model.nv - 6; ++k) {
+    u_eps[k] += alpha;
+    u_plus = u0 + u_eps;
+    fun.evaluate(x0, u_plus, x0, *fdata);
+    cone_partial_du_fd.col(k) = (fdata->value_ - cone0) / alpha;
+    u_eps[k] = 0.;
+  }
+  std::cout << (cone_partial_dx_fd - cone_partial_dx).norm() << std::endl;
+  BOOST_CHECK(cone_partial_dx_fd.isApprox(cone_partial_dx, sqrt(alpha)));
+  BOOST_CHECK(cone_partial_du_fd.isApprox(cone_partial_du, sqrt(alpha)));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/tests/forces.cpp
+++ b/tests/forces.cpp
@@ -9,6 +9,8 @@
 #include <aligator/modelling/multibody/contact-force.hpp>
 #include <aligator/modelling/multibody/multibody-wrench-cone.hpp>
 
+#ifdef ALIGATOR_PINOCCHIO_V3
+
 BOOST_AUTO_TEST_SUITE(forces)
 
 BOOST_AUTO_TEST_CASE(contact_forces) {
@@ -231,3 +233,5 @@ BOOST_AUTO_TEST_CASE(wrench_cone) {
 }
 
 BOOST_AUTO_TEST_SUITE_END()
+
+#endif

--- a/tests/forces.cpp
+++ b/tests/forces.cpp
@@ -5,11 +5,10 @@
 #include <proxsuite-nlp/modelling/spaces/multibody.hpp>
 
 #include <boost/test/unit_test.hpp>
-#include <iostream>
-#include <aligator/modelling/multibody/contact-force.hpp>
-#include <aligator/modelling/multibody/multibody-wrench-cone.hpp>
 
 #ifdef ALIGATOR_PINOCCHIO_V3
+#include <aligator/modelling/multibody/contact-force.hpp>
+#include <aligator/modelling/multibody/multibody-wrench-cone.hpp>
 
 BOOST_AUTO_TEST_SUITE(forces)
 

--- a/tests/forces.cpp
+++ b/tests/forces.cpp
@@ -57,10 +57,6 @@ BOOST_AUTO_TEST_CASE(contact_forces) {
   constraint_models.push_back(ci_RF);
   constraint_data.push_back(RigidConstraintData(ci_RF));
 
-  Eigen::DenseIndex constraint_dim = 0;
-  for (size_t k = 0; k < constraint_models.size(); ++k)
-    constraint_dim += constraint_models[k].size();
-
   const double mu0 = 0.;
   ProximalSettings prox_settings(1e-12, mu0, 1);
 
@@ -196,13 +192,17 @@ BOOST_AUTO_TEST_CASE(wrench_cone) {
   cone_partial_dx = fdata->Jx_;
   cone_partial_du = fdata->Ju_;
 
+  std::cout << "cone_dx" << cone_partial_dx << std::endl;
+  std::cout << "cone_du" << cone_partial_du << std::endl;
+
   // Data_fd
-  MatrixXd cone_partial_dx_fd(6, model.nv * 2);
+  MatrixXd cone_partial_dx_fd(17, model.nv * 2);
   cone_partial_dx_fd.setZero();
-  MatrixXd cone_partial_du_fd(6, model.nv - 6);
+  MatrixXd cone_partial_du_fd(17, model.nv - 6);
   cone_partial_du_fd.setZero();
 
   const VectorXd cone0 = fdata->value_;
+  std::cout << "value " << fdata->value_ << std::endl;
   VectorXd v_eps(VectorXd::Zero(model.nv * 2));
   VectorXd u_eps(VectorXd::Zero(model.nv - 6));
   VectorXd x_plus(model.nq + model.nv);
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE(wrench_cone) {
     cone_partial_du_fd.col(k) = (fdata->value_ - cone0) / alpha;
     u_eps[k] = 0.;
   }
-  std::cout << (cone_partial_dx_fd - cone_partial_dx).norm() << std::endl;
+
   BOOST_CHECK(cone_partial_dx_fd.isApprox(cone_partial_dx, sqrt(alpha)));
   BOOST_CHECK(cone_partial_du_fd.isApprox(cone_partial_du, sqrt(alpha)));
 }

--- a/tests/python/test_kinodynamics.py
+++ b/tests/python/test_kinodynamics.py
@@ -37,6 +37,44 @@ def test_centroidal_momentum():
 
     x, d, x0 = sample_gauss(space)
     u0 = np.random.randn(nu)
+
+    href = np.random.randn(6)
+
+    fun = aligator.CentroidalMomentumResidual(space.ndx, nu, model, href)
+    fdata = fun.createData()
+
+    fun_fd = aligator.FiniteDifferenceHelper(space, fun, FD_EPS)
+    fdata2 = fun_fd.createData()
+    fun.evaluate(x0, u0, x0, fdata)
+    fun_fd.evaluate(x0, u0, x0, fdata2)
+    assert np.allclose(fdata.value, fdata2.value)
+
+    fun_fd.computeJacobians(x0, u0, x0, fdata2)
+    J_fd = fdata2.Jx
+    J_fd_u = fdata2.Ju
+    assert fdata.Jx.shape == J_fd.shape
+    assert fdata.Ju.shape == J_fd_u.shape
+
+    for i in range(100):
+        du = np.random.randn(nu) * sample_factor
+        u1 = u0 + du
+        x, d, x0 = sample_gauss(space)
+        fun.evaluate(x0, u1, x0, fdata)
+        fun.computeJacobians(x0, u1, x0, fdata)
+        fun_fd.evaluate(x0, u1, x0, fdata2)
+        fun_fd.computeJacobians(x0, u1, x0, fdata2)
+        assert np.linalg.norm(fdata.Ju - fdata2.Ju) <= THRESH
+        assert np.linalg.norm(fdata.Jx - fdata2.Jx) <= THRESH
+
+
+def test_centroidal_momentum_derivative():
+    space = manifolds.MultibodyPhaseSpace(model)
+    force_size = 3
+    nk = 3
+    nu = force_size * nk + model.nv - 6
+
+    x, d, x0 = sample_gauss(space)
+    u0 = np.random.randn(nu)
     contact_states = [True, False, True]
 
     contact_ids = [


### PR DESCRIPTION
This PR adds force and wrench cone costs for the multibody case. For now the costs recompute the constrained dynamics of the contact although it is already done in multibodyConstrainedDynamics. In the future the common data update will fix this redundant computation.