### PR TITLE
Set policy CMP0167 and CMP0169 to avoid warnings with CMake 3.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fix RiccatiSolverDense initialization ([#174](https://github.com/Simple-Robotics/aligator/pull/174))
+- Remove CMake CMP0167 and CMP0169 warnings ([#176](https://github.com/Simple-Robotics/aligator/pull/176))
 
 ### Added
 - Add compatibility with jrl-cmakemodules workspace ([#172](https://github.com/Simple-Robotics/aligator/pull/172))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,11 @@ set(DOXYGEN_USE_TEMPLATE_CSS YES)
 set(DOXYGEN_HTML_HEADER "${PROJECT_SOURCE_DIR}/doc/header.html")
 set(DOXYGEN_HTML_STYLESHEET "")
 
+# Use BoostConfig module distributed by boost library instead of using FindBoost module distributed
+# by CMake
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 include(${JRL_CMAKE_MODULES}/base.cmake)
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,14 @@ list(FILTER LIB_HEADERS EXCLUDE REGEX ${PROJECT_SOURCE_DIR}/include/aligator/com
 option(ENABLE_TRACY_PROFILING "Enable Tracy profiler" OFF)
 option(DOWNLOAD_TRACY "Use FetchContent to install Tracy." ON)
 if(DOWNLOAD_TRACY)
+
+  # We use FetchContent_Populate because we need EXCLUDE_FROM_ALL to avoid
+  # installing Tracy with aligator.
+  # We can directly use EXCLUDE_FROM_ALL in FetchContent_Declare when CMake minimum version
+  # will be 3.28.
+  if(POLICY CMP0169)
+    cmake_policy(SET CMP0169 OLD)
+  endif()
   FetchContent_Declare(
     tracy
     GIT_REPOSITORY https://github.com/Simple-Robotics/tracy.git


### PR DESCRIPTION
CMake 3.30 don't package anymore the FindBoost.cmake file. Instead, it encourage to use the BoostModule.cmake distributed by Boost.

To avoid a warning message, we must set the CMP0167 policy to NEW.

CMP0167 deprecate FetchContent_populate.