### PR TITLE
[solvers] use placement-new for creating worksapce and results structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Use placement-new for `Workspace` and `Results` in solvers (FDDP and ProxDDP)
+
 ### Fixed
+
 - Fix RiccatiSolverDense initialization ([#174](https://github.com/Simple-Robotics/aligator/pull/174))
 - Remove CMake CMP0167 and CMP0169 warnings ([#176](https://github.com/Simple-Robotics/aligator/pull/176))
 
 ### Added
+
 - Add compatibility with jrl-cmakemodules workspace ([#172](https://github.com/Simple-Robotics/aligator/pull/172))
 
 ## [0.6.1] - 2024-05-27

--- a/include/aligator/solvers/fddp/solver-fddp.hxx
+++ b/include/aligator/solvers/fddp/solver-fddp.hxx
@@ -23,8 +23,8 @@ SolverFDDPTpl<Scalar>::SolverFDDPTpl(const Scalar tol, VerboseLevel verbose,
 template <typename Scalar>
 void SolverFDDPTpl<Scalar>::setup(const Problem &problem) {
   problem.checkIntegrity();
-  results_ = Results(problem);
-  workspace_ = Workspace(problem);
+  new (&results_) Results(problem);
+  new (&workspace_) Workspace(problem);
   // check if there are any constraints other than dynamics and throw a warning
   std::vector<std::size_t> idx_where_constraints;
   for (std::size_t i = 0; i < problem.numSteps(); i++) {

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -118,8 +118,8 @@ Scalar SolverProxDDPTpl<Scalar>::tryLinearStep(const Problem &problem,
 template <typename Scalar>
 void SolverProxDDPTpl<Scalar>::setup(const Problem &problem) {
   problem.checkIntegrity();
-  workspace_ = Workspace(problem);
-  results_ = Results(problem);
+  new (&workspace_) Workspace(problem);
+  new (&results_) Results(problem);
   linesearch_.setOptions(ls_params);
 
   workspace_.configureScalers(problem, mu_penal_, DefaultScaling<Scalar>{});


### PR DESCRIPTION
The change avoids requirement a copy-assignment operator exists (and avoids a call to said operator to initialize the members).