### PR TITLE
[fwd.hpp] add deprecations for uses of Eigen::aligned_allocator

### DIFF
--- a/.github/workflows/macos-linux-conda.yml
+++ b/.github/workflows/macos-linux-conda.yml
@@ -8,6 +8,7 @@ on:
       - '.gitlab-ci.yml'
       - '.gitignore'
       - '*.md'
+      - 'CHANGELOG.md'
       - 'CITATION.cff'
       - 'CITATIONS.bib'
   pull_request:
@@ -17,6 +18,7 @@ on:
       - '.gitlab-ci.yml'
       - '.gitignore'
       - '*.md'
+      - 'CHANGELOG.md'
       - 'CITATION.cff'
       - 'CITATIONS.bib'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use placement-new for `Workspace` and `Results` in solvers (FDDP and ProxDDP)
+- Deprecate typedef for `std::vector<T, Eigen::aligned_allocator<T>>`
+- Deprecate function template `allocate_shared_eigen_aligned<T>`
 
 ### Fixed
 

--- a/include/aligator/fwd.hpp
+++ b/include/aligator/fwd.hpp
@@ -119,12 +119,19 @@ template <typename Scalar> struct ResultsTpl;
 template <typename Scalar> struct FilterTpl;
 
 template <typename T>
-using StdVectorEigenAligned = std::vector<T, Eigen::aligned_allocator<T>>;
+using StdVectorEigenAligned ALIGATOR_DEPRECATED_MESSAGE(
+    "Aligator now requires C++17 and the Eigen::aligned_allocator<T> class is "
+    "no longer useful. Please use std::vector<T> instead, this typedef will "
+    "change to be an alias of that of the future, then will be removed.") =
+    std::vector<T, Eigen::aligned_allocator<T>>;
 
 template <typename T, typename... Args>
+ALIGATOR_DEPRECATED_MESSAGE(
+    "Aligator now requires C++17 and the Eigen::aligned_allocator<T> class is "
+    "no longer useful. This function is now just an alias for "
+    "std::make_shared, and will be removed in the future.")
 inline auto allocate_shared_eigen_aligned(Args &&...args) {
-  return std::allocate_shared<T>(Eigen::aligned_allocator<T>(),
-                                 std::forward<Args>(args)...);
+  return std::make_shared<T>(std::forward<Args>(args)...);
 }
 
 } // namespace aligator

--- a/include/aligator/modelling/centroidal/angular-acceleration.hpp
+++ b/include/aligator/modelling/centroidal/angular-acceleration.hpp
@@ -51,7 +51,7 @@ public:
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 
   ContactMap contact_map_;

--- a/include/aligator/modelling/centroidal/angular-momentum.hpp
+++ b/include/aligator/modelling/centroidal/angular-momentum.hpp
@@ -36,7 +36,7 @@ public:
   void computeJacobians(const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 
 protected:

--- a/include/aligator/modelling/centroidal/centroidal-acceleration.hpp
+++ b/include/aligator/modelling/centroidal/centroidal-acceleration.hpp
@@ -51,7 +51,7 @@ public:
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 
   ContactMap contact_map_;

--- a/include/aligator/modelling/centroidal/centroidal-translation.hpp
+++ b/include/aligator/modelling/centroidal/centroidal-translation.hpp
@@ -27,7 +27,7 @@ public:
   void computeJacobians(const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 
 protected:

--- a/include/aligator/modelling/centroidal/centroidal-wrapper.hpp
+++ b/include/aligator/modelling/centroidal/centroidal-wrapper.hpp
@@ -33,7 +33,7 @@ public:
   void computeJacobians(const ConstVectorRef &x, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 
   FunPtr centroidal_cost_;

--- a/include/aligator/modelling/centroidal/friction-cone.hpp
+++ b/include/aligator/modelling/centroidal/friction-cone.hpp
@@ -39,7 +39,7 @@ public:
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 
 protected:

--- a/include/aligator/modelling/centroidal/linear-momentum.hpp
+++ b/include/aligator/modelling/centroidal/linear-momentum.hpp
@@ -35,7 +35,7 @@ public:
   void computeJacobians(const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 
 protected:

--- a/include/aligator/modelling/centroidal/wrench-cone.hpp
+++ b/include/aligator/modelling/centroidal/wrench-cone.hpp
@@ -41,7 +41,7 @@ public:
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 
 protected:

--- a/include/aligator/modelling/dynamics/centroidal-fwd.hxx
+++ b/include/aligator/modelling/dynamics/centroidal-fwd.hxx
@@ -82,7 +82,7 @@ void CentroidalFwdDynamicsTpl<Scalar>::dForward(const ConstVectorRef &x,
 template <typename Scalar>
 shared_ptr<ContinuousDynamicsDataTpl<Scalar>>
 CentroidalFwdDynamicsTpl<Scalar>::createData() const {
-  return allocate_shared_eigen_aligned<Data>(this);
+  return std::make_shared<Data>(this);
 }
 
 template <typename Scalar>

--- a/include/aligator/modelling/dynamics/continuous-centroidal-fwd.hxx
+++ b/include/aligator/modelling/dynamics/continuous-centroidal-fwd.hxx
@@ -96,7 +96,7 @@ void ContinuousCentroidalFwdDynamicsTpl<Scalar>::dForward(
 template <typename Scalar>
 shared_ptr<ContinuousDynamicsDataTpl<Scalar>>
 ContinuousCentroidalFwdDynamicsTpl<Scalar>::createData() const {
-  return allocate_shared_eigen_aligned<Data>(this);
+  return std::make_shared<Data>(this);
 }
 
 template <typename Scalar>

--- a/include/aligator/modelling/dynamics/kinodynamics-fwd.hxx
+++ b/include/aligator/modelling/dynamics/kinodynamics-fwd.hxx
@@ -194,7 +194,7 @@ void KinodynamicsFwdDynamicsTpl<Scalar>::dForward(const ConstVectorRef &x,
 template <typename Scalar>
 shared_ptr<ContinuousDynamicsDataTpl<Scalar>>
 KinodynamicsFwdDynamicsTpl<Scalar>::createData() const {
-  return allocate_shared_eigen_aligned<Data>(this);
+  return std::make_shared<Data>(this);
 }
 
 template <typename Scalar>

--- a/include/aligator/modelling/dynamics/multibody-constraint-fwd.hxx
+++ b/include/aligator/modelling/dynamics/multibody-constraint-fwd.hxx
@@ -59,7 +59,7 @@ void MultibodyConstraintFwdDynamicsTpl<Scalar>::dForward(const ConstVectorRef &,
 template <typename Scalar>
 shared_ptr<ContinuousDynamicsDataTpl<Scalar>>
 MultibodyConstraintFwdDynamicsTpl<Scalar>::createData() const {
-  return allocate_shared_eigen_aligned<Data>(*this);
+  return std::make_shared<Data>(*this);
 }
 
 template <typename Scalar>

--- a/include/aligator/modelling/dynamics/multibody-free-fwd.hxx
+++ b/include/aligator/modelling/dynamics/multibody-free-fwd.hxx
@@ -64,7 +64,7 @@ void MultibodyFreeFwdDynamicsTpl<Scalar>::dForward(const ConstVectorRef &x,
 template <typename Scalar>
 shared_ptr<ContinuousDynamicsDataTpl<Scalar>>
 MultibodyFreeFwdDynamicsTpl<Scalar>::createData() const {
-  return allocate_shared_eigen_aligned<Data>(this);
+  return std::make_shared<Data>(this);
 }
 
 template <typename Scalar>

--- a/include/aligator/modelling/multibody/center-of-mass-translation.hpp
+++ b/include/aligator/modelling/multibody/center-of-mass-translation.hpp
@@ -45,7 +45,7 @@ public:
   void computeJacobians(const ConstVectorRef &x, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 
 protected:

--- a/include/aligator/modelling/multibody/center-of-mass-velocity.hpp
+++ b/include/aligator/modelling/multibody/center-of-mass-velocity.hpp
@@ -35,7 +35,7 @@ public:
   void computeJacobians(const ConstVectorRef &x, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(*this);
+    return std::make_shared<Data>(*this);
   }
 
 protected:

--- a/include/aligator/modelling/multibody/centroidal-momentum-derivative.hpp
+++ b/include/aligator/modelling/multibody/centroidal-momentum-derivative.hpp
@@ -58,7 +58,7 @@ public:
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 };
 

--- a/include/aligator/modelling/multibody/centroidal-momentum.hpp
+++ b/include/aligator/modelling/multibody/centroidal-momentum.hpp
@@ -40,7 +40,7 @@ public:
   void setReference(const Eigen::Ref<const Vector6s> &h_new) { h_ref_ = h_new; }
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 };
 

--- a/include/aligator/modelling/multibody/contact-force.hpp
+++ b/include/aligator/modelling/multibody/contact-force.hpp
@@ -68,7 +68,7 @@ public:
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 };
 

--- a/include/aligator/modelling/multibody/fly-high.hpp
+++ b/include/aligator/modelling/multibody/fly-high.hpp
@@ -28,7 +28,7 @@ struct FlyHighResidualTpl : UnaryFunctionTpl<_Scalar>, frame_api {
   void computeJacobians(const ConstVectorRef &x, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(*this);
+    return std::make_shared<Data>(*this);
   }
 
   const auto &getModel() const { return pmodel_; }

--- a/include/aligator/modelling/multibody/frame-placement.hpp
+++ b/include/aligator/modelling/multibody/frame-placement.hpp
@@ -44,7 +44,7 @@ public:
   void computeJacobians(const ConstVectorRef &x, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(*this);
+    return std::make_shared<Data>(*this);
   }
 
 protected:

--- a/include/aligator/modelling/multibody/frame-translation.hpp
+++ b/include/aligator/modelling/multibody/frame-translation.hpp
@@ -37,7 +37,7 @@ struct FrameTranslationResidualTpl : UnaryFunctionTpl<_Scalar>, frame_api {
   void computeJacobians(const ConstVectorRef &x, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(*this);
+    return std::make_shared<Data>(*this);
   }
 
 protected:

--- a/include/aligator/modelling/multibody/frame-velocity.hpp
+++ b/include/aligator/modelling/multibody/frame-velocity.hpp
@@ -40,7 +40,7 @@ public:
   void computeJacobians(const ConstVectorRef &x, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(*this);
+    return std::make_shared<Data>(*this);
   }
 
 protected:

--- a/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
+++ b/include/aligator/modelling/multibody/multibody-wrench-cone.hpp
@@ -78,7 +78,7 @@ public:
                         const ConstVectorRef &, BaseData &data) const;
 
   shared_ptr<BaseData> createData() const {
-    return allocate_shared_eigen_aligned<Data>(this);
+    return std::make_shared<Data>(this);
   }
 };
 


### PR DESCRIPTION
`aligator` now requires C++17, hence there is no longer any use for the `Eigen::aligned_allocator<T>` template class. Hence all aliases for the relevant std::vector type and use of std::allocate_shared (which takes an allocator type as argument) are useless.

This PR deprecates both the typedef for `std::vector<T, Eigen::aligned_allocator<T>>` and the `aligator::allocate_shared_eigen_aligned` function template, and removes all use of the later (replaced by vanilla `make_shared`).