### PR TITLE
Call destructor first before doing placement-new on workspace and results objects

### DIFF
--- a/include/aligator/solvers/fddp/solver-fddp.hxx
+++ b/include/aligator/solvers/fddp/solver-fddp.hxx
@@ -23,6 +23,8 @@ SolverFDDPTpl<Scalar>::SolverFDDPTpl(const Scalar tol, VerboseLevel verbose,
 template <typename Scalar>
 void SolverFDDPTpl<Scalar>::setup(const Problem &problem) {
   problem.checkIntegrity();
+  results_.~Results();
+  workspace_.~Workspace();
   new (&results_) Results(problem);
   new (&workspace_) Workspace(problem);
   // check if there are any constraints other than dynamics and throw a warning

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -118,8 +118,10 @@ Scalar SolverProxDDPTpl<Scalar>::tryLinearStep(const Problem &problem,
 template <typename Scalar>
 void SolverProxDDPTpl<Scalar>::setup(const Problem &problem) {
   problem.checkIntegrity();
-  new (&workspace_) Workspace(problem);
+  results_.~Results();
+  workspace_.~Workspace();
   new (&results_) Results(problem);
+  new (&workspace_) Workspace(problem);
   linesearch_.setOptions(ls_params);
 
   workspace_.configureScalers(problem, mu_penal_, DefaultScaling<Scalar>{});


### PR DESCRIPTION
This PR fixes solver-fddp.hxx and solver-proxddp.hxx to explicitly call the destructor on the workspace and results objects before doing placement new in the `Solver::setup()` member function.

The previous behaviour created a memory leak before the previous object never got destroyed.

Closes #189 