### PR TITLE
[modelling/costs] Add getResidual() templated getter for composite cost functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Getter `getResidual<Derived>()` for composite cost functions ([#198](https://github.com/Simple-Robotics/aligator/pull/198))
+
 ### Changed
 
 - Change storage for `ConstraintStack` to using two `std::vector<polymorphic<>>` the struct `StageConstraintTpl` is now merely a convenient API shortcut for the end-user.

--- a/include/aligator/modelling/costs/log-residual-cost.hpp
+++ b/include/aligator/modelling/costs/log-residual-cost.hpp
@@ -39,6 +39,17 @@ template <typename Scalar> struct LogResidualCostTpl : CostAbstractTpl<Scalar> {
     return std::make_shared<Data>(this->ndx(), this->nu,
                                   residual_->createData());
   }
+
+  /// @brief Get a pointer to the underlying type of the residual, by attempting
+  /// to cast.
+  template <typename Derived> Derived *getResidual() {
+    return dynamic_cast<Derived *>(&*residual_);
+  }
+
+  /// @copybrief getResidual().
+  template <typename Derived> const Derived *getResidual() const {
+    return dynamic_cast<const Derived *>(&*residual_);
+  }
 };
 
 extern template struct LogResidualCostTpl<context::Scalar>;

--- a/include/aligator/modelling/costs/quad-residual-cost.hpp
+++ b/include/aligator/modelling/costs/quad-residual-cost.hpp
@@ -44,6 +44,17 @@ struct QuadraticResidualCostTpl : CostAbstractTpl<_Scalar> {
     return std::make_shared<Data>(this->ndx(), this->nu,
                                   residual_->createData());
   }
+
+  /// @brief Get a pointer to the underlying type of the residual, by attempting
+  /// to cast.
+  template <typename Derived> Derived *getResidual() {
+    return dynamic_cast<Derived *>(&*residual_);
+  }
+
+  /// @copybrief getResidual().
+  template <typename Derived> const Derived *getResidual() const {
+    return dynamic_cast<const Derived *>(&*residual_);
+  }
 };
 
 extern template struct QuadraticResidualCostTpl<context::Scalar>;

--- a/tests/continuous.cpp
+++ b/tests/continuous.cpp
@@ -12,10 +12,10 @@ BOOST_AUTO_TEST_CASE(create_data) {
   pinocchio::buildModels::humanoidRandom(model);
 
   using StateMultibody = proxsuite::nlp::MultibodyPhaseSpace<double>;
-  auto spaceptr = std::make_shared<StateMultibody>(model);
+  const StateMultibody state{model};
   Eigen::MatrixXd B(model.nv, model.nv);
   B.setIdentity();
-  dynamics::MultibodyFreeFwdDynamicsTpl<double> contdyn(*spaceptr, B);
+  dynamics::MultibodyFreeFwdDynamicsTpl<double> contdyn(state, B);
 
   using ContDataAbstract = dynamics::ContinuousDynamicsDataTpl<double>;
   using Data = dynamics::MultibodyFreeFwdDataTpl<double>;


### PR DESCRIPTION

The function template `QuadraticResidualCost::getResidual<T>()` will attempt a cast to pointer-type `T*` or `const T*` to the expected actual type of the stored residual function.