### PR TITLE
[modelling] Change CostStack backend to an unordered_map type

### DIFF
--- a/.github/workflows/macos-linux-conda.yml
+++ b/.github/workflows/macos-linux-conda.yml
@@ -79,7 +79,7 @@ jobs:
           -DBUILD_CROCODDYL_COMPAT=ON \
           -DBUILD_BENCHMARKS=ON \
           -DBUILD_EXAMPLES=ON
-        cmake --build .
+        cmake --build . -j2
         ctest --output-on-failure
         cmake --install .
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Getter `getResidual<Derived>()` for composite cost functions ([#198](https://github.com/Simple-Robotics/aligator/pull/198))
+- Getter `getComponent<Derived>()` for `CostStack` ([#199](https://github.com/Simple-Robotics/aligator/pull/199))
 
 ### Changed
 
+- Change storage of `CostStack` to `boost::unordered::unordered_map`, pointing to pair of cost function and weight ([#199](https://github.com/Simple-Robotics/aligator/pull/199))
 - Change storage for `ConstraintStack` to using two `std::vector<polymorphic<>>` the struct `StageConstraintTpl` is now merely a convenient API shortcut for the end-user.
 - Remove `StageConstraintTpl::nr()` (in C++ only)
 - Update minimum required version of eigenpy to 3.7.0

--- a/bindings/python/src/modelling/expose-cost-stack.cpp
+++ b/bindings/python/src/modelling/expose-cost-stack.cpp
@@ -6,6 +6,12 @@
 #include <eigenpy/std-pair.hpp>
 #include <eigenpy/variant.hpp>
 #if EIGENPY_VERSION_AT_LEAST(3, 9, 1)
+#define ALIGATOR_EIGENPY_HAS_MAP_SUPPORT 1
+#else
+#define ALIGATOR_EIGENPY_HAS_MAP_SUPPORT 1
+#endif
+
+#if ALIGATOR_EIGENPY_HAS_MAP_SUPPORT
 #include <eigenpy/std-map.hpp>
 #endif
 
@@ -21,6 +27,7 @@ void exposeCostStack() {
   using CostStackData = CostStackDataTpl<Scalar>;
   using CostKey = CostStack::CostKey;
   using PolyCost = CostStack::PolyCost;
+  using PolyManifold = xyz::polymorphic<Manifold>;
   using CostItem = CostStack::CostItem;
   using CostMap = CostStack::CostMap;
   eigenpy::StdPairConverter<CostItem>::registration();
@@ -30,14 +37,19 @@ void exposeCostStack() {
     bp::scope scope =
         bp::class_<CostStack, bp::bases<CostAbstract>>(
             "CostStack", "A weighted sum of other cost functions.", bp::no_init)
-            .def(bp::init<xyz::polymorphic<Manifold>, const int,
-                          const std::vector<PolyCost> &,
-                          const std::vector<Scalar> &>(
-                ("self"_a, "space", "nu", "components"_a = bp::list(),
-                 "weights"_a = bp::list())))
+            .def(
+                bp::init<PolyManifold, const int, const std::vector<PolyCost> &,
+                         const std::vector<Scalar> &>(
+                    ("self"_a, "space", "nu", "components"_a = bp::list(),
+                     "weights"_a = bp::list())))
             .def(bp::init<const PolyCost &>(("self"_a, "cost")))
-            .def_readwrite("components", &CostStack::components_,
-                           "Components of this cost stack.")
+#if ALIGATOR_EIGENPY_HAS_MAP_SUPPORT
+            .def(bp::init<PolyManifold, int, const CostMap &>(
+                ("self"_a, "components"),
+                "Construct the CostStack from a CostMap object."))
+            .def_readonly("components", &CostStack::components_,
+                          "Components of this cost stack.")
+#endif
             .def(
                 "addCost",
                 +[](CostStack &self, const PolyCost &cost,
@@ -45,8 +57,7 @@ void exposeCostStack() {
                   // return
                   self.addCost(cost, weight);
                 },
-                ("self"_a, "cost", "weight"_a = 1.),
-                bp::return_internal_reference<>())
+                ("self"_a, "cost", "weight"_a = 1.))
             .def(
                 "addCost",
                 +[](CostStack &self, CostKey key, const PolyCost &cost,
@@ -54,12 +65,11 @@ void exposeCostStack() {
                   // return
                   self.addCost(key, cost, weight);
                 },
-                ("self"_a, "key", "cost", "weight"_a = 1.),
-                bp::return_internal_reference<>())
+                ("self"_a, "key", "cost", "weight"_a = 1.))
             .def("size", &CostStack::size, "Get the number of cost components.")
             .def(CopyableVisitor<CostStack>())
             .def(PolymorphicMultiBaseVisitor<CostAbstract>());
-#if EIGENPY_VERSION_AT_LEAST(3, 9, 1)
+#if ALIGATOR_EIGENPY_HAS_MAP_SUPPORT
     eigenpy::GenericMapVisitor<CostMap, true>::expose("CostMap");
 #endif
   }
@@ -70,7 +80,7 @@ void exposeCostStack() {
         bp::class_<CostStackData, bp::bases<CostData>>(
             "CostStackData", "Data struct for CostStack.", bp::no_init)
             .def_readonly("sub_cost_data", &CostStackData::sub_cost_data);
-#if EIGENPY_VERSION_AT_LEAST(3, 9, 1)
+#if ALIGATOR_EIGENPY_HAS_MAP_SUPPORT
     eigenpy::GenericMapVisitor<CostStackData::DataMap, true>::expose("DataMap");
 #endif
   }

--- a/bindings/python/src/modelling/expose-cost-stack.cpp
+++ b/bindings/python/src/modelling/expose-cost-stack.cpp
@@ -8,7 +8,7 @@
 #if EIGENPY_VERSION_AT_LEAST(3, 9, 1)
 #define ALIGATOR_EIGENPY_HAS_MAP_SUPPORT 1
 #else
-#define ALIGATOR_EIGENPY_HAS_MAP_SUPPORT 1
+#define ALIGATOR_EIGENPY_HAS_MAP_SUPPORT 0
 #endif
 
 #if ALIGATOR_EIGENPY_HAS_MAP_SUPPORT
@@ -52,19 +52,17 @@ void exposeCostStack() {
 #endif
             .def(
                 "addCost",
-                +[](CostStack &self, const PolyCost &cost,
-                    const Scalar weight) {
-                  // return
-                  self.addCost(cost, weight);
-                },
+                +[](CostStack &self, const PolyCost &cost, const Scalar weight)
+                    -> PolyCost & { return self.addCost(cost, weight).first; },
+                bp::return_internal_reference<>(),
                 ("self"_a, "cost", "weight"_a = 1.))
             .def(
                 "addCost",
                 +[](CostStack &self, CostKey key, const PolyCost &cost,
-                    const Scalar weight) {
-                  // return
-                  self.addCost(key, cost, weight);
+                    const Scalar weight) -> PolyCost & {
+                  return self.addCost(key, cost, weight).first;
                 },
+                bp::return_internal_reference<>(),
                 ("self"_a, "key", "cost", "weight"_a = 1.))
             .def("size", &CostStack::size, "Get the number of cost components.")
             .def(CopyableVisitor<CostStack>())

--- a/bindings/python/src/modelling/expose-cost-stack.cpp
+++ b/bindings/python/src/modelling/expose-cost-stack.cpp
@@ -4,6 +4,7 @@
 #include "aligator/modelling/costs/sum-of-costs.hpp"
 
 #include <eigenpy/std-pair.hpp>
+#include <eigenpy/std-map.hpp>
 #include <eigenpy/variant.hpp>
 
 namespace aligator {
@@ -23,40 +24,50 @@ void exposeCostStack() {
   eigenpy::StdPairConverter<CostItem>::registration();
   eigenpy::VariantConverter<CostKey>::registration();
 
-  bp::class_<CostStack, bp::bases<CostAbstract>>(
-      "CostStack", "A weighted sum of other cost functions.", bp::no_init)
-      .def(bp::init<xyz::polymorphic<Manifold>, const int,
-                    const std::vector<PolyCost> &, const std::vector<Scalar> &>(
-          ("self"_a, "space", "nu", "components"_a = bp::list(),
-           "weights"_a = bp::list())))
-      .def(bp::init<const PolyCost &>(("self"_a, "cost")))
-      // .def_readwrite("components", &CostStack::components_,
-      //                "Components of this cost stack.")
-      .def(
-          "addCost",
-          +[](CostStack &self, const PolyCost &cost, const Scalar weight) {
-            // return
-            self.addCost(cost, weight);
-          },
-          ("self"_a, "cost", "weight"_a = 1.),
-          bp::return_internal_reference<>())
-      .def(
-          "addCost",
-          +[](CostStack &self, CostKey key, const PolyCost &cost,
-              const Scalar weight) {
-            // return
-            self.addCost(key, cost, weight);
-          },
-          ("self"_a, "key", "cost", "weight"_a = 1.),
-          bp::return_internal_reference<>())
-      .def("size", &CostStack::size, "Get the number of cost components.")
-      .def(CopyableVisitor<CostStack>())
-      .def(PolymorphicMultiBaseVisitor<CostAbstract>());
+  {
+    bp::scope scope =
+        bp::class_<CostStack, bp::bases<CostAbstract>>(
+            "CostStack", "A weighted sum of other cost functions.", bp::no_init)
+            .def(bp::init<xyz::polymorphic<Manifold>, const int,
+                          const std::vector<PolyCost> &,
+                          const std::vector<Scalar> &>(
+                ("self"_a, "space", "nu", "components"_a = bp::list(),
+                 "weights"_a = bp::list())))
+            .def(bp::init<const PolyCost &>(("self"_a, "cost")))
+            .def_readwrite("components", &CostStack::components_,
+                           "Components of this cost stack.")
+            .def(
+                "addCost",
+                +[](CostStack &self, const PolyCost &cost,
+                    const Scalar weight) {
+                  // return
+                  self.addCost(cost, weight);
+                },
+                ("self"_a, "cost", "weight"_a = 1.),
+                bp::return_internal_reference<>())
+            .def(
+                "addCost",
+                +[](CostStack &self, CostKey key, const PolyCost &cost,
+                    const Scalar weight) {
+                  // return
+                  self.addCost(key, cost, weight);
+                },
+                ("self"_a, "key", "cost", "weight"_a = 1.),
+                bp::return_internal_reference<>())
+            .def("size", &CostStack::size, "Get the number of cost components.")
+            .def(CopyableVisitor<CostStack>())
+            .def(PolymorphicMultiBaseVisitor<CostAbstract>());
+    eigenpy::GenericMapVisitor<CostMap, true>::expose("CostMap");
+  }
 
-  bp::register_ptr_to_python<shared_ptr<CostStackData>>();
-  bp::class_<CostStackData, bp::bases<CostData>>(
-      "CostStackData", "Data struct for CostStack.", bp::no_init)
-      .def_readonly("sub_cost_data", &CostStackData::sub_cost_data);
+  {
+    bp::register_ptr_to_python<shared_ptr<CostStackData>>();
+    bp::scope scope =
+        bp::class_<CostStackData, bp::bases<CostData>>(
+            "CostStackData", "Data struct for CostStack.", bp::no_init)
+            .def_readonly("sub_cost_data", &CostStackData::sub_cost_data);
+    eigenpy::GenericMapVisitor<CostStackData::DataMap, true>::expose("DataMap");
+  }
 }
 
 } // namespace python

--- a/bindings/python/src/modelling/expose-cost-stack.cpp
+++ b/bindings/python/src/modelling/expose-cost-stack.cpp
@@ -3,8 +3,8 @@
 
 #include "aligator/modelling/costs/sum-of-costs.hpp"
 
-#include <eigenpy/std-map.hpp>
 #include <eigenpy/std-pair.hpp>
+#include <eigenpy/variant.hpp>
 
 namespace aligator {
 namespace python {
@@ -21,6 +21,7 @@ void exposeCostStack() {
   using CostItem = CostStack::CostItem;
   using CostMap = CostStack::CostMap;
   eigenpy::StdPairConverter<CostItem>::registration();
+  eigenpy::VariantConverter<CostKey>::registration();
 
   bp::class_<CostStack, bp::bases<CostAbstract>>(
       "CostStack", "A weighted sum of other cost functions.", bp::no_init)
@@ -33,15 +34,18 @@ void exposeCostStack() {
       //                "Components of this cost stack.")
       .def(
           "addCost",
-          +[](CostStack &self, const PolyCost &cost, const Scalar weight)
-              -> CostItem & { return self.addCost(cost, weight); },
+          +[](CostStack &self, const PolyCost &cost, const Scalar weight) {
+            // return
+            self.addCost(cost, weight);
+          },
           ("self"_a, "cost", "weight"_a = 1.),
           bp::return_internal_reference<>())
       .def(
           "addCost",
           +[](CostStack &self, CostKey key, const PolyCost &cost,
-              const Scalar weight) -> CostItem & {
-            return self.addCost(key, cost, weight);
+              const Scalar weight) {
+            // return
+            self.addCost(key, cost, weight);
           },
           ("self"_a, "key", "cost", "weight"_a = 1.),
           bp::return_internal_reference<>())

--- a/bindings/python/src/modelling/expose-cost-stack.cpp
+++ b/bindings/python/src/modelling/expose-cost-stack.cpp
@@ -4,8 +4,10 @@
 #include "aligator/modelling/costs/sum-of-costs.hpp"
 
 #include <eigenpy/std-pair.hpp>
-#include <eigenpy/std-map.hpp>
 #include <eigenpy/variant.hpp>
+#if EIGENPY_VERSION_AT_LEAST(3, 9, 1)
+#include <eigenpy/std-map.hpp>
+#endif
 
 namespace aligator {
 namespace python {
@@ -57,7 +59,9 @@ void exposeCostStack() {
             .def("size", &CostStack::size, "Get the number of cost components.")
             .def(CopyableVisitor<CostStack>())
             .def(PolymorphicMultiBaseVisitor<CostAbstract>());
+#if EIGENPY_VERSION_AT_LEAST(3, 9, 1)
     eigenpy::GenericMapVisitor<CostMap, true>::expose("CostMap");
+#endif
   }
 
   {
@@ -66,7 +70,9 @@ void exposeCostStack() {
         bp::class_<CostStackData, bp::bases<CostData>>(
             "CostStackData", "Data struct for CostStack.", bp::no_init)
             .def_readonly("sub_cost_data", &CostStackData::sub_cost_data);
+#if EIGENPY_VERSION_AT_LEAST(3, 9, 1)
     eigenpy::GenericMapVisitor<CostStackData::DataMap, true>::expose("DataMap");
+#endif
   }
 }
 

--- a/examples/talos-walk-utils.cpp
+++ b/examples/talos-walk-utils.cpp
@@ -187,8 +187,8 @@ TrajOptProblem defineLocomotionProblem(const std::size_t T_ss,
 
     auto rcost = CostStack(stage_space, nu);
 
-    rcost.addCost(QuadraticStateCost(stage_space, nu, x0, w_x));
-    rcost.addCost(QuadraticControlCost(stage_space, u0, w_u));
+    rcost.addCost("quad_state", QuadraticStateCost(stage_space, nu, x0, w_x));
+    rcost.addCost("quad_control", QuadraticControlCost(stage_space, u0, w_u));
     pin::SE3 LF_placement = rdata.oMf[foot_frame_ids[0]];
     pin::SE3 RF_placement = rdata.oMf[foot_frame_ids[1]];
     std::shared_ptr<FramePlacementResidual> frame_fn_RF;
@@ -198,13 +198,15 @@ TrajOptProblem defineLocomotionProblem(const std::size_t T_ss,
       foot_traj(RF_placement.translation(), T_ss, ts);
       frame_fn_RF = std::make_shared<FramePlacementResidual>(
           stage_space.ndx(), nu, rmodel, RF_placement, foot_frame_ids[1]);
-      rcost.addCost(QuadraticResidualCost(stage_space, *frame_fn_RF, w_LFRF));
+      rcost.addCost("frame_fn_RF",
+                    QuadraticResidualCost(stage_space, *frame_fn_RF, w_LFRF));
       break;
     case RIGHT:
       foot_traj(LF_placement.translation(), T_ss, ts);
       frame_fn_LF = std::make_shared<FramePlacementResidual>(
           stage_space.ndx(), nu, rmodel, LF_placement, foot_frame_ids[0]);
-      rcost.addCost(QuadraticResidualCost(stage_space, *frame_fn_LF, w_LFRF));
+      rcost.addCost("frame_fn_LF",
+                    QuadraticResidualCost(stage_space, *frame_fn_LF, w_LFRF));
       break;
     case DOUBLE:
       ts = 0;
@@ -216,7 +218,7 @@ TrajOptProblem defineLocomotionProblem(const std::size_t T_ss,
   }
   auto ter_space = MultibodyPhaseSpace(rmodel);
   auto term_cost = CostStack(ter_space, nu);
-  term_cost.addCost(QuadraticStateCost(ter_space, nu, x0, w_x));
+  term_cost.addCost("quad_state", QuadraticStateCost(ter_space, nu, x0, w_x));
 
   return TrajOptProblem(x0, stage_models, term_cost);
 }

--- a/include/aligator/modelling/costs/sum-of-costs.hpp
+++ b/include/aligator/modelling/costs/sum-of-costs.hpp
@@ -34,7 +34,7 @@ template <typename _Scalar> struct CostStackTpl : CostAbstractTpl<_Scalar> {
   /// @brief    Check the dimension of a component.
   /// @returns  A bool value indicating whether the component is OK to be added
   /// to this instance.
-  bool checkDimension(const xyz::polymorphic<CostBase> comp) const;
+  bool checkDimension(const CostBase &comp) const;
 
   /// @brief  Constructor with a specified dimension, and optional vector of
   /// components and weights.
@@ -46,7 +46,13 @@ template <typename _Scalar> struct CostStackTpl : CostAbstractTpl<_Scalar> {
                const CostMap &comps)
       : CostBase(space, nu), components_(comps) {
     for (const auto &[key, item] : comps) {
-      this->checkDimension(item.first);
+      auto &cost = *item.first;
+      if (!this->checkDimension(cost)) {
+        ALIGATOR_DOMAIN_ERROR(fmt::format(
+            "Cannot add new component due to inconsistent input dimensions "
+            "(got ({:d}, {:d}), expected ({:d}, {:d}))",
+            cost.ndx(), cost.nu, this->ndx(), this->nu));
+      }
     }
   }
 

--- a/include/aligator/modelling/costs/sum-of-costs.hpp
+++ b/include/aligator/modelling/costs/sum-of-costs.hpp
@@ -112,8 +112,6 @@ struct CostStackDataTpl : CostDataAbstractTpl<_Scalar> {
 };
 } // namespace aligator
 
-#include "aligator/modelling/costs/sum-of-costs.hxx"
-
 #ifdef ALIGATOR_ENABLE_TEMPLATE_INSTANTIATION
 #include "aligator/modelling/costs/sum-of-costs.txx"
 #endif

--- a/include/aligator/modelling/costs/sum-of-costs.hxx
+++ b/include/aligator/modelling/costs/sum-of-costs.hxx
@@ -16,7 +16,7 @@ CostStackTpl<Scalar>::CostStackTpl(xyz::polymorphic<Manifold> space,
     ALIGATOR_RUNTIME_ERROR(msg);
   } else {
     for (std::size_t i = 0; i < comps.size(); i++) {
-      if (!this->checkDimension(comps[i])) {
+      if (!this->checkDimension(*comps[i])) {
         auto msg = fmt::format("Component #{:d} has wrong input dimensions "
                                "({:d}, {:d}) (expected "
                                "({:d}, {:d}))",
@@ -39,16 +39,15 @@ CostStackTpl<Scalar>::CostStackTpl(const PolyCost &cost)
 }
 
 template <typename Scalar>
-bool CostStackTpl<Scalar>::checkDimension(
-    const xyz::polymorphic<CostBase> comp) const {
-  return (comp->nx() == this->nx()) && (comp->ndx() == this->ndx()) &&
-         (comp->nu == this->nu);
+bool CostStackTpl<Scalar>::checkDimension(const CostBase &comp) const {
+  return (comp.nx() == this->nx()) && (comp.ndx() == this->ndx()) &&
+         (comp.nu == this->nu);
 }
 
 template <typename Scalar>
 auto CostStackTpl<Scalar>::addCost(const CostKey &key, const PolyCost &cost,
                                    const Scalar weight) -> CostItem & {
-  if (!this->checkDimension(cost)) {
+  if (!this->checkDimension(*cost)) {
     ALIGATOR_DOMAIN_ERROR(fmt::format(
         "Cannot add new component due to inconsistent input dimensions "
         "(got ({:d}, {:d}), expected ({:d}, {:d}))",

--- a/include/aligator/modelling/costs/sum-of-costs.hxx
+++ b/include/aligator/modelling/costs/sum-of-costs.hxx
@@ -6,9 +6,9 @@ namespace aligator {
 template <typename Scalar>
 CostStackTpl<Scalar>::CostStackTpl(xyz::polymorphic<Manifold> space,
                                    const int nu,
-                                   const std::vector<CostPtr> &comps,
+                                   const std::vector<PolyCost> &comps,
                                    const std::vector<Scalar> &weights)
-    : CostBase(space, nu), components_(comps), weights_(weights) {
+    : CostBase(space, nu) {
   if (comps.size() != weights.size()) {
     auto msg = fmt::format(
         "Inconsistent number of components ({:d}) and weights ({:d}).",
@@ -25,12 +25,19 @@ CostStackTpl<Scalar>::CostStackTpl(xyz::polymorphic<Manifold> space,
         ALIGATOR_RUNTIME_ERROR(msg);
       }
     }
+
+    for (std::size_t i = 0; i < comps.size(); i++) {
+      components_.emplace(
+          std::make_pair(i, std::make_pair(comps[i], weights[i])));
+    }
   }
 }
 
 template <typename Scalar>
-CostStackTpl<Scalar>::CostStackTpl(const CostPtr &cost)
-    : CostStackTpl(cost->space, cost->nu, {cost}, {1.}) {}
+CostStackTpl<Scalar>::CostStackTpl(const PolyCost &cost)
+    : CostBase(cost->space, cost->nu) {
+  components_.emplace(0UL, std::make_pair(cost, 1.0));
+}
 
 template <typename Scalar>
 bool CostStackTpl<Scalar>::checkDimension(
@@ -39,20 +46,17 @@ bool CostStackTpl<Scalar>::checkDimension(
          (comp->nu == this->nu);
 }
 
-template <typename Scalar> std::size_t CostStackTpl<Scalar>::size() const {
-  return components_.size();
-}
-
 template <typename Scalar>
-void CostStackTpl<Scalar>::addCost(const CostPtr &cost, const Scalar weight) {
+auto CostStackTpl<Scalar>::addCost(const CostKey &key, const PolyCost &cost,
+                                   const Scalar weight) -> CostItem & {
   if (!this->checkDimension(cost)) {
     ALIGATOR_DOMAIN_ERROR(fmt::format(
         "Cannot add new component due to inconsistent input dimensions "
         "(got ({:d}, {:d}), expected ({:d}, {:d}))",
         cost->ndx(), cost->nu, this->ndx(), this->nu));
   }
-  components_.push_back(cost);
-  weights_.push_back(weight);
+  components_.emplace(key, std::make_pair(cost, weight));
+  return components_.at(key);
 }
 
 template <typename Scalar>
@@ -61,9 +65,9 @@ void CostStackTpl<Scalar>::evaluate(const ConstVectorRef &x,
                                     CostData &data) const {
   SumCostData &d = static_cast<SumCostData &>(data);
   d.value_ = 0.;
-  for (std::size_t i = 0; i < components_.size(); i++) {
-    components_[i]->evaluate(x, u, *d.sub_cost_data[i]);
-    d.value_ += this->weights_[i] * d.sub_cost_data[i]->value_;
+  for (const auto &[key, item] : components_) {
+    item.first->evaluate(x, u, *d.sub_cost_data[key]);
+    d.value_ += item.second * d.sub_cost_data[key]->value_;
   }
 }
 
@@ -73,9 +77,9 @@ void CostStackTpl<Scalar>::computeGradients(const ConstVectorRef &x,
                                             CostData &data) const {
   SumCostData &d = static_cast<SumCostData &>(data);
   d.grad_.setZero();
-  for (std::size_t i = 0; i < components_.size(); i++) {
-    components_[i]->computeGradients(x, u, *d.sub_cost_data[i]);
-    d.grad_.noalias() += this->weights_[i] * d.sub_cost_data[i]->grad_;
+  for (const auto &[key, item] : components_) {
+    item.first->computeGradients(x, u, *d.sub_cost_data[key]);
+    d.grad_.noalias() += item.second * d.sub_cost_data[key]->grad_;
   }
 }
 
@@ -85,9 +89,9 @@ void CostStackTpl<Scalar>::computeHessians(const ConstVectorRef &x,
                                            CostData &data) const {
   SumCostData &d = static_cast<SumCostData &>(data);
   d.hess_.setZero();
-  for (std::size_t i = 0; i < components_.size(); i++) {
-    components_[i]->computeHessians(x, u, *d.sub_cost_data[i]);
-    d.hess_.noalias() += this->weights_[i] * d.sub_cost_data[i]->hess_;
+  for (const auto &[key, item] : components_) {
+    item.first->computeHessians(x, u, *d.sub_cost_data[key]);
+    d.hess_.noalias() += item.second * d.sub_cost_data[key]->hess_;
   }
 }
 
@@ -102,8 +106,8 @@ CostStackTpl<Scalar>::createData() const {
 template <typename Scalar>
 CostStackDataTpl<Scalar>::CostStackDataTpl(const CostStackTpl<Scalar> &obj)
     : CostData(obj.ndx(), obj.nu) {
-  for (std::size_t i = 0; i < obj.size(); i++) {
-    sub_cost_data.push_back(obj.components_[i]->createData());
+  for (const auto &[key, item] : obj.components_) {
+    sub_cost_data[key] = item.first->createData();
   }
 }
 

--- a/include/aligator/modelling/costs/sum-of-costs.hxx
+++ b/include/aligator/modelling/costs/sum-of-costs.hxx
@@ -27,8 +27,7 @@ CostStackTpl<Scalar>::CostStackTpl(xyz::polymorphic<Manifold> space,
     }
 
     for (std::size_t i = 0; i < comps.size(); i++) {
-      components_.emplace(
-          std::make_pair(i, std::make_pair(comps[i], weights[i])));
+      components_.emplace(i, std::make_pair(comps[i], weights[i]));
     }
   }
 }

--- a/src/modelling/costs/sum-of-costs.cpp
+++ b/src/modelling/costs/sum-of-costs.cpp
@@ -1,4 +1,4 @@
-#include "aligator/modelling/costs/sum-of-costs.hpp"
+#include "aligator/modelling/costs/sum-of-costs.hxx"
 
 namespace aligator {
 

--- a/tests/python/test_costs.py
+++ b/tests/python/test_costs.py
@@ -41,6 +41,12 @@ def test_cost_stack():
         assert np.allclose(data1.Lxx, Q)
         assert np.allclose(data1.Luu, R)
 
+    if eigenpy.__version__ >= "3.9.1":
+        # test other API for cost,
+        # building from dict
+        cost_stack = CostStack(space, nu, {"quad": (rcost, 1.0)})
+        assert cost_stack.size() == 1
+
 
 def test_composite_cost():
     space = manifolds.VectorSpace(3)

--- a/tests/python/test_costs.py
+++ b/tests/python/test_costs.py
@@ -2,6 +2,7 @@ from aligator import QuadraticCost, CostStack
 from aligator import manifolds
 import aligator
 import numpy as np
+import eigenpy
 
 import pytest
 
@@ -145,14 +146,15 @@ def test_stack_error():
     rcost = QuadraticCost(Q, R)
     cost_stack.addCost(rcost)  # optional
 
-    cost_stack.components
-    print(cost_stack.components.todict())
+    if eigenpy.__version__ >= "3.9.1":
+        print(cost_stack.components.todict())
 
     rc2 = QuadraticCost(np.eye(3), np.eye(nu))
     rc3 = QuadraticCost(np.eye(nx), np.eye(nu * 2))
 
-    cost_data = cost_stack.createData()
-    print(cost_data.sub_cost_data.todict())
+    if eigenpy.__version__ >= "3.9.1":
+        cost_data = cost_stack.createData()
+        print(cost_data.sub_cost_data.todict())
 
     with pytest.raises(Exception) as e_info:
         cost_stack.addCost(rc2)

--- a/tests/python/test_costs.py
+++ b/tests/python/test_costs.py
@@ -145,11 +145,14 @@ def test_stack_error():
     rcost = QuadraticCost(Q, R)
     cost_stack.addCost(rcost)  # optional
 
+    cost_stack.components
+    print(cost_stack.components.todict())
+
     rc2 = QuadraticCost(np.eye(3), np.eye(nu))
     rc3 = QuadraticCost(np.eye(nx), np.eye(nu * 2))
 
     cost_data = cost_stack.createData()
-    print(cost_data.sub_cost_data.tolist())
+    print(cost_data.sub_cost_data.todict())
 
     with pytest.raises(Exception) as e_info:
         cost_stack.addCost(rc2)


### PR DESCRIPTION
- Also adds a template getter for the component cost functions
- `addCost()` now has an overload taking a key (either a `std::size_t` or a string)
- `addCost()` returns a reference to the pair of cost function component and weight

Resolves #195 