### PR TITLE
Fixing include of LU from Eigen

### DIFF
--- a/include/aligator/modelling/dynamics/kinodynamics-fwd.hpp
+++ b/include/aligator/modelling/dynamics/kinodynamics-fwd.hpp
@@ -3,7 +3,7 @@
 
 #include "aligator/modelling/dynamics/ode-abstract.hpp"
 
-#include <Eigen/src/LU/PartialPivLU.h>
+#include <Eigen/LU>
 #include <proxsuite-nlp/modelling/spaces/multibody.hpp>
 #include <pinocchio/multibody/model.hpp>
 


### PR DESCRIPTION
This PR fixes the include of LU from Eigen in the kynodynamics file which was breaking compilation.