### PR TITLE
Cycle the Riccati solver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - python: Add helper `aligator.has_pinocchio_features()` ([#206](https://github.com/Simple-Robotics/aligator/pull/206))
 - Add a cycleProblem function that properly rotates the problem data for MPC applications ([#215](https://github.com/Simple-Robotics/aligator/pull/215))
 - Add a DCM cost function
+- Add a cycleAppend function in Riccati solver headers to cycle the LQR solver
 
 ### Changed
 

--- a/gar/include/aligator/gar/dense-riccati.hpp
+++ b/gar/include/aligator/gar/dense-riccati.hpp
@@ -61,6 +61,7 @@ public:
                std::vector<VectorXs> &vs, std::vector<VectorXs> &lbdas,
                const std::optional<ConstVectorRef> &theta = std::nullopt) const;
 
+  void cycleAppend(const KnotType &knot);
   VectorRef getFeedforward(size_t i) { return datas[i].ff.matrix(); }
   RowMatrixRef getFeedback(size_t i) { return datas[i].fb.matrix(); }
 

--- a/gar/include/aligator/gar/dense-riccati.hxx
+++ b/gar/include/aligator/gar/dense-riccati.hxx
@@ -244,4 +244,26 @@ bool RiccatiSolverDense<Scalar>::forward(
   }
   return true;
 }
+
+template <typename Scalar>
+void RiccatiSolverDense<Scalar>::cycleAppend(const KnotType &knot) {
+  auto N = (uint)problem_->horizon();
+
+  rotate_vec_left(datas, 0, 1);
+  datas[N - 1] = FactorData(init_factor(knot));
+  rotate_vec_left(Pxx, 0, 1);
+  rotate_vec_left(Pxt);
+  rotate_vec_left(Ptt, 0, 1);
+  rotate_vec_left(px, 0, 1);
+  rotate_vec_left(pt, 0, 1);
+
+  uint nx = knot.nx;
+  uint nth = knot.nth;
+  Pxx[N - 1].setZero(nx, nx);
+  Pxt[N - 1].setZero(nx, nth);
+  Ptt[N - 1].setZero(nth, nth);
+  px[N - 1].setZero(nx);
+  pt[N - 1].setZero(nth);
+};
+
 } // namespace aligator::gar

--- a/gar/include/aligator/gar/parallel-solver.hpp
+++ b/gar/include/aligator/gar/parallel-solver.hpp
@@ -83,6 +83,7 @@ public:
                VectorOfVectors &lbdas,
                const std::optional<ConstVectorRef> & = std::nullopt) const;
 
+  void cycleAppend(const KnotType &knot);
   VectorRef getFeedforward(size_t i) { return datas[i].ff.matrix(); }
   RowMatrixRef getFeedback(size_t i) { return datas[i].fb.matrix(); }
 

--- a/gar/include/aligator/gar/proximal-riccati.hpp
+++ b/gar/include/aligator/gar/proximal-riccati.hpp
@@ -32,6 +32,7 @@ public:
                std::vector<VectorXs> &vs, std::vector<VectorXs> &lbdas,
                const std::optional<ConstVectorRef> &theta = std::nullopt) const;
 
+  void cycleAppend(const KnotType &knot);
   VectorRef getFeedforward(size_t i) { return datas[i].ff.matrix(); }
   RowMatrixRef getFeedback(size_t i) { return datas[i].fb.matrix(); }
 

--- a/gar/include/aligator/gar/proximal-riccati.hxx
+++ b/gar/include/aligator/gar/proximal-riccati.hxx
@@ -73,4 +73,14 @@ bool ProximalRiccatiSolver<Scalar>::forward(
   return Impl::forwardImpl(problem_->stages, datas, xs, us, vs, lbdas, theta_);
 }
 
+template <typename Scalar>
+void ProximalRiccatiSolver<Scalar>::cycleAppend(const KnotType &knot) {
+  rotate_vec_left(datas, 0, 1);
+  datas[problem_->horizon() - 1] =
+      StageFactor<Scalar>(knot.nx, knot.nu, knot.nc, knot.nx2, knot.nth);
+  thGrad.setZero();
+  thHess.setZero();
+  kkt0.mat.setZero();
+};
+
 } // namespace aligator::gar

--- a/gar/include/aligator/gar/riccati-base.hpp
+++ b/gar/include/aligator/gar/riccati-base.hpp
@@ -3,7 +3,8 @@
 #pragma once
 
 #include "aligator/math.hpp"
-
+#include "aligator/gar/lqr-problem.hpp"
+#include "aligator/utils/mpc-util.hpp"
 #include <optional>
 
 namespace aligator {
@@ -12,6 +13,7 @@ namespace gar {
 template <typename _Scalar> class RiccatiSolverBase {
 public:
   using Scalar = _Scalar;
+  using LQRKnot = LQRKnotTpl<double>;
   ALIGATOR_DYNAMIC_TYPEDEFS_WITH_ROW_TYPES(Scalar);
 
   virtual bool backward(const Scalar mudyn, const Scalar mueq) = 0;
@@ -20,6 +22,8 @@ public:
   forward(std::vector<VectorXs> &xs, std::vector<VectorXs> &us,
           std::vector<VectorXs> &vs, std::vector<VectorXs> &lbdas,
           const std::optional<ConstVectorRef> &theta_ = std::nullopt) const = 0;
+
+  virtual void cycleAppend(const LQRKnot &knot) = 0;
 
   /// For applicable solvers, updates the first feedback gain in-place to
   /// correspond to the first Riccati gain.

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -157,7 +157,7 @@ void SolverProxDDPTpl<Scalar>::cycleProblem(
     const Problem &problem, shared_ptr<StageDataTpl<Scalar>> data) {
   results_.cycleAppend(problem, problem.getInitState());
   workspace_.cycleAppend(problem, data);
-
+  // linearSolver_->cycleAppend(workspace_.knots[workspace_.nsteps - 1]);
   switch (linear_solver_choice) {
   case LQSolverChoice::SERIAL: {
     linearSolver_ = std::make_unique<gar::ProximalRiccatiSolver<Scalar>>(

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -157,33 +157,7 @@ void SolverProxDDPTpl<Scalar>::cycleProblem(
     const Problem &problem, shared_ptr<StageDataTpl<Scalar>> data) {
   results_.cycleAppend(problem, problem.getInitState());
   workspace_.cycleAppend(problem, data);
-  // linearSolver_->cycleAppend(workspace_.knots[workspace_.nsteps - 1]);
-  switch (linear_solver_choice) {
-  case LQSolverChoice::SERIAL: {
-    linearSolver_ = std::make_unique<gar::ProximalRiccatiSolver<Scalar>>(
-        workspace_.lqr_problem);
-    break;
-  }
-  case LQSolverChoice::PARALLEL: {
-    if (rollout_type_ == RolloutType::NONLINEAR) {
-      ALIGATOR_RUNTIME_ERROR(
-          "Nonlinear rollouts not supported with the parallel solver.");
-    }
-#ifndef ALIGATOR_MULTITHREADING
-    ALIGATOR_RUNTIME_ERROR(
-        "Aligator was not compiled with OpenMP support. The parallel Riccati "
-        "solver is not available.");
-#else
-    linearSolver_ = std::make_unique<gar::ParallelRiccatiSolver<Scalar>>(
-        workspace_.lqr_problem, num_threads_);
-#endif
-    break;
-  case LQSolverChoice::STAGEDENSE:
-    linearSolver_ = std::make_unique<gar::RiccatiSolverDense<Scalar>>(
-        workspace_.lqr_problem);
-    break;
-  }
-  }
+  linearSolver_->cycleAppend(workspace_.knots[workspace_.nsteps - 1]);
 }
 
 /// TODO: REWORK FOR NEW MULTIPLIERS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ set(TEST_NAMES
     solver-storage
     utils
     forces
+    cycling
 )
 
 foreach(test_name ${TEST_NAMES})

--- a/tests/cycling.cpp
+++ b/tests/cycling.cpp
@@ -1,0 +1,108 @@
+#include "aligator/core/traj-opt-problem.hpp"
+#include "aligator/solvers/proxddp/solver-proxddp.hpp"
+#include "aligator/core/explicit-dynamics.hpp"
+#include "aligator/core/cost-abstract.hpp"
+#include "aligator/utils/mpc-util.hpp"
+#include <proxsuite-nlp/modelling/spaces/pinocchio-groups.hpp>
+#include <proxsuite-nlp/third-party/polymorphic_cxx14.hpp>
+#include <boost/test/unit_test.hpp>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
+
+using namespace aligator;
+using context::SolverProxDDP;
+
+/// @brief    Addition dynamics.
+/// @details  It maps \f$(x,u)\f$ to \f$ x + u \f$.
+struct MyModel : ExplicitDynamicsModelTpl<double> {
+  using Manifold = ManifoldAbstractTpl<double>;
+  using ManifoldPtr = xyz::polymorphic<Manifold>;
+  using ExplicitData = ExplicitDynamicsDataTpl<double>;
+  explicit MyModel(const ManifoldPtr &space)
+      : ExplicitDynamicsModelTpl<double>(space, space->ndx()) {}
+
+  void forward(const ConstVectorRef &x, const ConstVectorRef &u,
+               ExplicitData &data) const {
+    space_next().integrate(x, u, data.xnext_);
+  }
+
+  void dForward(const ConstVectorRef &x, const ConstVectorRef &u,
+                ExplicitData &data) const {
+    space_next().Jintegrate(x, u, data.Jx_, 0);
+    space_next().Jintegrate(x, u, data.Ju_, 1);
+  }
+};
+
+struct MyCost : CostAbstractTpl<double> {
+  using CostAbstractTpl<double>::CostAbstractTpl;
+  void evaluate(const ConstVectorRef &, const ConstVectorRef &,
+                CostData &data) const {
+    data.value_ = 0.;
+  }
+
+  void computeGradients(const ConstVectorRef &, const ConstVectorRef &,
+                        CostData &data) const {
+    data.grad_.setZero();
+  }
+
+  void computeHessians(const ConstVectorRef &, const ConstVectorRef &,
+                       CostData &data) const {
+    data.hess_.setZero();
+  }
+};
+
+using Manifold = proxsuite::nlp::SETpl<3, double>;
+using StageModel = aligator::StageModelTpl<double>;
+using EqualityConstraint = proxsuite::nlp::EqualityConstraintTpl<double>;
+
+struct MyFixture {
+  Manifold space;
+  const int nu;
+  const MyModel dyn_model;
+  const MyCost cost;
+  TrajOptProblemTpl<double> problem;
+  std::vector<shared_ptr<StageDataTpl<double>>> problem_data;
+
+  MyFixture()
+      : space(Manifold()), nu(space.ndx()), dyn_model(MyModel(space)),
+        cost(MyCost(space, nu)), problem(space.neutral(), nu, space, cost) {
+    for (size_t i = 0; i < 20; i++) {
+      auto stage = StageModel(cost, dyn_model);
+      if (i >= 10) {
+        auto func = StateErrorResidualTpl<double>(space, nu, space.neutral());
+        stage.addConstraint(func, EqualityConstraint());
+      }
+      problem.addStage(stage);
+      problem_data.push_back(stage.createData());
+    }
+  }
+};
+
+BOOST_AUTO_TEST_CASE(test_cycling) {
+  MyFixture f;
+
+  auto nu = f.nu;
+  auto nsteps = f.problem.numSteps();
+  auto &space = f.space;
+
+  double tol = 1e-6;
+  double mu_init = 1e-8;
+  SolverProxDDP ddp(tol, mu_init);
+  ddp.rollout_type_ = RolloutType::LINEAR;
+  ddp.max_iters = 10;
+  ddp.verbose_ = VERBOSE;
+  ddp.linear_solver_choice = LQSolverChoice::SERIAL;
+
+  ddp.setup(f.problem);
+  bool conv = ddp.run(f.problem);
+  BOOST_CHECK(conv);
+
+  for (size_t i = 0; i < 30; i++) {
+    f.problem.replaceStageCircular(f.problem.stages_[0]);
+    rotate_vec_left(f.problem_data);
+    ddp.cycleProblem(f.problem, f.problem_data[nsteps - 1]);
+    bool conv = ddp.run(f.problem);
+    BOOST_CHECK(conv);
+  }
+}

--- a/tests/cycling.cpp
+++ b/tests/cycling.cpp
@@ -7,9 +7,6 @@
 #include <proxsuite-nlp/third-party/polymorphic_cxx14.hpp>
 #include <boost/test/unit_test.hpp>
 
-#include <fmt/format.h>
-#include <fmt/ostream.h>
-
 using namespace aligator;
 using context::SolverProxDDP;
 
@@ -82,10 +79,7 @@ struct MyFixture {
 BOOST_AUTO_TEST_CASE(test_cycling) {
   MyFixture f;
 
-  auto nu = f.nu;
   auto nsteps = f.problem.numSteps();
-  auto &space = f.space;
-
   double tol = 1e-6;
   double mu_init = 1e-8;
   SolverProxDDP ddp(tol, mu_init);


### PR DESCRIPTION
This PR aims at adding a function to efficiently cycle the three different kind of linear solvers so as to avoid full reallocation at each MPC control cycle. Discussions are open to decide what is the best way to achieve it.