### PR TITLE
Re-define ALM params struct internally to `aligator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change the API of the wrench cost functions to allow 3D and 6D forces
 - Separate centroidal wrench cone and multibody wrench cone costs
 - Add a contact_name item to the CostMap structure
+- Re-define ALM params struct internally to aligator ([#219](https://github.com/Simple-Robotics/aligator/pull/219))
 
 ### Fixed
 

--- a/include/aligator/context.hpp
+++ b/include/aligator/context.hpp
@@ -13,7 +13,6 @@ ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
 
 using Manifold = ManifoldAbstractTpl<Scalar>;
 
-using BCLParams = BCLParamsTpl<Scalar>;
 using StageFunction = StageFunctionTpl<Scalar>;
 using UnaryFunction = UnaryFunctionTpl<Scalar>;
 using StageFunctionData = StageFunctionDataTpl<Scalar>;

--- a/include/aligator/fwd.hpp
+++ b/include/aligator/fwd.hpp
@@ -24,8 +24,6 @@ namespace aligator {
 
 // NOLINTBEGIN(misc-unused-using-decls)
 
-// Use the shared_ptr used in proxsuite-nlp.
-using proxsuite::nlp::BCLParamsTpl;
 using proxsuite::nlp::ConstraintSetBase;
 using proxsuite::nlp::ManifoldAbstractTpl;
 // Use the math_types template from proxsuite-nlp.

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -443,11 +443,11 @@ bool SolverProxDDPTpl<Scalar>::run(const Problem &problem,
   if (!workspace_.isInitialized() || !results_.isInitialized()) {
     ALIGATOR_RUNTIME_ERROR("workspace and results were not allocated yet!");
   }
-  if (mu_init < mu_lower_bound) {
+  if (mu_init < bcl_params.mu_lower_bound) {
     ALIGATOR_WARNING(
         "SolverProxDDP",
         fmt::format("Initial value of mu_init < mu_lower_bound ({:.3g})",
-                    mu_lower_bound));
+                    bcl_params.mu_lower_bound));
     setAlmPenalty(mu_init);
   }
 

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -6,7 +6,6 @@
 #include "solver-proxddp.hpp"
 #include "merit-function.hpp"
 #include "aligator/core/lagrangian.hpp"
-#include "aligator/gar/utils.hpp"
 #include "aligator/utils/forward-dyn.hpp"
 
 #include "aligator/gar/proximal-riccati.hpp"

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -444,6 +444,13 @@ bool SolverProxDDPTpl<Scalar>::run(const Problem &problem,
   if (!workspace_.isInitialized() || !results_.isInitialized()) {
     ALIGATOR_RUNTIME_ERROR("workspace and results were not allocated yet!");
   }
+  if (mu_init < mu_lower_bound) {
+    ALIGATOR_WARNING(
+        "SolverProxDDP",
+        fmt::format("Initial value of mu_init < mu_lower_bound ({:.3g})",
+                    mu_lower_bound));
+    setAlmPenalty(mu_init);
+  }
 
   check_trajectory_and_assign(problem, xs_init, us_init, results_.xs,
                               results_.us);


### PR DESCRIPTION
We remove use of proxsuite-nlp's `BCLParams` struct and instead add an inner struct `AlmParams` to `SolverProxDDP`. This allows us to move some aligator-specific parameters inside of this struct.