### PR TITLE
SolverProxDDP: remove solver parameter `rho_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - All map types are now `boost::unordered_map` ([#203](https://github.com/Simple-Robotics/aligator/pull/203))
 - Separate CostFiniteDifference out of finite-difference.hpp ([#212](https://github.com/Simple-Robotics/aligator/pull/212))
-- Remove constraint scalers (including header `core/alm-weights.hpp`) from ProxDDP algorithm ([#214](https://github.com/Simple-Robotics/aligator/pull/214))
 - Change the API of the wrench cost functions to allow 3D and 6D forces
 - Separate centroidal wrench cone and multibody wrench cone costs
 - Add a contact_name item to the CostMap structure
 - Re-define ALM params struct internally to aligator ([#219](https://github.com/Simple-Robotics/aligator/pull/219))
+
+### Removed
+
+- Remove constraint scalers (including header `core/alm-weights.hpp`) from ProxDDP algorithm ([#214](https://github.com/Simple-Robotics/aligator/pull/214))
+- SolverProxDDP: remove parameter solver parameter `rho_` ([#221](https://github.com/Simple-Robotics/aligator/pull/221))
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Remove constraint scalers (including header `core/alm-weights.hpp`) from ProxDDP algorithm ([#214](https://github.com/Simple-Robotics/aligator/pull/214))
-- SolverProxDDP: remove parameter solver parameter `rho_` ([#221](https://github.com/Simple-Robotics/aligator/pull/221))
+- SolverProxDDP: remove solver parameter `rho_` ([#221](https://github.com/Simple-Robotics/aligator/pull/221))
 
 ### Fixed
 

--- a/bench/croc-talos-arm.cpp
+++ b/bench/croc-talos-arm.cpp
@@ -83,7 +83,8 @@ template <uint NPROC> void BM_aligator(benchmark::State &state) {
   getInitialGuesses(croc_problem, xs_i, us_i);
 
   const double mu_init = 1e-10;
-  SolverProxDDP solver(TOL, mu_init, 0., maxiters, get_verbose_flag(verbose));
+  SolverProxDDP solver(TOL, mu_init, maxiters);
+  solver.verbose_ = get_verbose_flag(verbose);
   solver.setNumThreads(NPROC);
   solver.setup(prob_wrap);
 

--- a/bench/lqr.cpp
+++ b/bench/lqr.cpp
@@ -70,7 +70,7 @@ static void BM_lqr_prox(benchmark::State &state) {
   SETUP_PROBLEM_VARS(nsteps);
   const T mu_init = 1e-10;
   const auto num_threads = static_cast<std::size_t>(state.range(1));
-  SolverProxDDPTpl<T> solver(TOL, mu_init, 0., max_iters, verbose);
+  SolverProxDDPTpl<T> solver(TOL, mu_init, max_iters, verbose);
   solver.linear_solver_choice = lqsc;
   solver.rollout_type_ = RolloutType::LINEAR;
   solver.force_initial_condition_ = false;

--- a/bench/talos-walk.cpp
+++ b/bench/talos-walk.cpp
@@ -41,7 +41,7 @@ static void BM_aligator(benchmark::State &state) {
   xs_i.assign(nsteps + 1, problem.getInitState());
   us_i.assign(nsteps, u0);
 
-  SolverProxDDPTpl<double> solver(TOL, mu_init, 0., maxiters, aligator::QUIET);
+  SolverProxDDPTpl<double> solver(TOL, mu_init, maxiters, aligator::QUIET);
 
   solver.rollout_type_ = aligator::RolloutType::LINEAR;
   solver.linear_solver_choice = lqsc;

--- a/bindings/python/src/expose-solver-prox.cpp
+++ b/bindings/python/src/expose-solver-prox.cpp
@@ -85,10 +85,10 @@ void exposeProxDDP() {
           "search directions and feedforward, feedback gains."
           " The solver instance initializes both a Workspace and a Results "
           "struct.",
-          bp::init<Scalar, Scalar, Scalar, std::size_t, VerboseLevel,
+          bp::init<const Scalar, const Scalar, std::size_t, VerboseLevel,
                    HessianApprox>(
-              ("self"_a, "tol", "mu_init"_a = 1e-2, "rho_init"_a = 0.,
-               "max_iters"_a = 1000, "verbose"_a = VerboseLevel::QUIET,
+              ("self"_a, "tol", "mu_init"_a = 1e-2, "max_iters"_a = 1000,
+               "verbose"_a = VerboseLevel::QUIET,
                "hess_approx"_a = HessianApprox::GAUSS_NEWTON)))
           .def("cycleProblem", &SolverType::cycleProblem,
                ("self"_a, "problem", "data"),
@@ -106,8 +106,6 @@ void exposeProxDDP() {
           .def_readwrite("mu_init", &SolverType::mu_init,
                          "Initial AL penalty parameter.")
           .add_property("mu", &SolverType::mu)
-          .def_readwrite("rho_init", &SolverType::rho_init,
-                         "Initial proximal regularization.")
           .def_readwrite(
               "rollout_max_iters", &SolverType::rollout_max_iters,
               "Maximum number of iterations when solving the forward dynamics.")
@@ -157,7 +155,6 @@ void exposeProxDDP() {
         ._c(dual_alpha)
         ._c(dual_beta)
         ._c(mu_update_factor)
-        ._c(rho_update_factor)
         ._c(constraints_al_scale)
         ._c(mu_lower_bound);
 #undef _c

--- a/examples/cartpole.py
+++ b/examples/cartpole.py
@@ -97,13 +97,10 @@ else:
 
 
 mu_init = 1e-2
-rho_init = 0.0
 verbose = aligator.VerboseLevel.VERBOSE
 TOL = 1e-4
 MAX_ITER = 300
-solver = aligator.SolverProxDDP(
-    TOL, mu_init, rho_init, max_iters=MAX_ITER, verbose=verbose
-)
+solver = aligator.SolverProxDDP(TOL, mu_init, max_iters=MAX_ITER, verbose=verbose)
 solver.rollout_type = aligator.ROLLOUT_LINEAR
 callback = aligator.HistoryCallback()
 solver.registerCallback("his", callback)

--- a/examples/centroidal.py
+++ b/examples/centroidal.py
@@ -230,10 +230,9 @@ problem.addTerminalConstraint(term_constraint_com)
 """ Solver initialization """
 TOL = 1e-5
 mu_init = 1e-8
-rho_init = 0.0
 max_iters = 100
 verbose = aligator.VerboseLevel.VERBOSE
-solver = aligator.SolverProxDDP(TOL, mu_init, rho_init, verbose=verbose)
+solver = aligator.SolverProxDDP(TOL, mu_init, verbose=verbose)
 solver.rollout_type = aligator.ROLLOUT_LINEAR
 solver.max_iters = max_iters
 solver.sa_strategy = aligator.SA_FILTER  # FILTER or LINESEARCH

--- a/examples/continuous-centroidal.py
+++ b/examples/continuous-centroidal.py
@@ -272,10 +272,9 @@ problem.addTerminalConstraint(term_constraint_com)
 # Solver initialization
 TOL = 1e-5
 mu_init = 1e-8
-rho_init = 0.0
 max_iters = 100
 verbose = aligator.VerboseLevel.VERBOSE
-solver = aligator.SolverProxDDP(TOL, mu_init, rho_init, verbose=verbose)
+solver = aligator.SolverProxDDP(TOL, mu_init, verbose=verbose)
 # solver = aligator.SolverFDDP(TOL, verbose=verbose)
 solver.rollout_type = aligator.ROLLOUT_LINEAR
 # print("LDLT algo choice:", solver.ldlt_algo_choice)

--- a/examples/croc_arm_manipulation.py
+++ b/examples/croc_arm_manipulation.py
@@ -190,7 +190,6 @@ if True:
     prox_problem = convertCrocoddylProblem(problem)
 
     # mu_init = 1e-7
-    # rho_init = 1e-10
     # proxsolver = aligator.SolverProxDDP(croc_dual_err * 0.8, 0.001, max_iters=300)
     proxsolver = aligator.SolverFDDP(tol=croc_dual_err)
     proxsolver.verbose = aligator.VerboseLevel.VERBOSE

--- a/examples/linear_euler.py
+++ b/examples/linear_euler.py
@@ -39,11 +39,10 @@ xs_init = [x0] * (nsteps + 1)
 us_init = [np.zeros(nu)] * nsteps
 
 mu_init = 0.001
-rho_init = 0.0
 tol = 1e-5
 verbose = aligator.VerboseLevel.VERBOSE
 
-solver = aligator.SolverProxDDP(tol, mu_init, rho_init, verbose=verbose)
+solver = aligator.SolverProxDDP(tol, mu_init, verbose=verbose)
 # solver = aligator.SolverFDDP(tol, verbose=verbose)
 
 solver.setup(problem)

--- a/examples/lqr.py
+++ b/examples/lqr.py
@@ -79,7 +79,7 @@ mu_init = 1e-3 if args.bounds else 1e-6
 rho_init = 0.0
 verbose = aligator.VerboseLevel.VERBOSE
 tol = 1e-8
-solver = aligator.SolverProxDDP(tol, mu_init, rho_init, verbose=verbose)
+solver = aligator.SolverProxDDP(tol, mu_init, verbose=verbose)
 
 his_cb = aligator.HistoryCallback()
 solver.registerCallback("his", his_cb)

--- a/examples/solo_kinodynamics.py
+++ b/examples/solo_kinodynamics.py
@@ -187,10 +187,9 @@ problem = aligator.TrajOptProblem(x0, stages, term_cost)
 
 TOL = 1e-5
 mu_init = 1e-8
-rho_init = 0.0
 max_iters = 100
 verbose = aligator.VerboseLevel.VERBOSE
-solver = aligator.SolverProxDDP(TOL, mu_init, rho_init, verbose=verbose)
+solver = aligator.SolverProxDDP(TOL, mu_init, verbose=verbose)
 # solver = aligator.SolverFDDP(TOL, verbose=verbose)
 solver.rollout_type = aligator.ROLLOUT_LINEAR
 solver.max_iters = max_iters

--- a/examples/talos-arm.cpp
+++ b/examples/talos-arm.cpp
@@ -20,8 +20,7 @@ int main(int, char **) {
   auto problem = aligator::compat::croc::convertCrocoddylProblem(croc_problem);
 
   double mu_init = 0.001;
-  SolverProxDDPTpl<double> solver(TOL, mu_init, 0., max_iters,
-                                  aligator::VERBOSE);
+  SolverProxDDPTpl<double> solver(TOL, mu_init, max_iters, aligator::VERBOSE);
 
   std::vector<VectorXd> xs_i, us_i;
   getInitialGuesses(croc_problem, xs_i, us_i);

--- a/examples/talos-walk.cpp
+++ b/examples/talos-walk.cpp
@@ -22,8 +22,7 @@ int main(int, char **) {
 
   auto problem = defineLocomotionProblem(T_ss, T_ds);
 
-  SolverProxDDPTpl<double> solver(TOL, mu_init, 0., max_iters,
-                                  aligator::VERBOSE);
+  SolverProxDDPTpl<double> solver(TOL, mu_init, max_iters, aligator::VERBOSE);
   std::vector<VectorXd> xs_i, us_i;
   Eigen::VectorXd u0 = Eigen::VectorXd::Zero(22);
   xs_i.assign(nsteps + 1, problem.getInitState());

--- a/examples/talos_arms.py
+++ b/examples/talos_arms.py
@@ -83,10 +83,9 @@ problem = aligator.TrajOptProblem(x0, stages, term_cost)
 
 TOL = 1e-5
 mu_init = 1e-3
-rho_init = 0.0
 max_iters = 200
 verbose = aligator.VerboseLevel.VERBOSE
-solver = aligator.SolverProxDDP(TOL, mu_init, rho_init, verbose=verbose)
+solver = aligator.SolverProxDDP(TOL, mu_init, verbose=verbose)
 solver.rollout_type = aligator.ROLLOUT_NONLINEAR
 # solver = aligator.SolverFDDP(TOL, verbose=verbose)
 solver.max_iters = max_iters

--- a/examples/talos_walk.py
+++ b/examples/talos_walk.py
@@ -286,10 +286,9 @@ problem = aligator.TrajOptProblem(x0, stages, term_cost)
 
 TOL = 1e-4
 mu_init = 1e-8
-rho_init = 0.0
 max_iters = 200
 verbose = aligator.VerboseLevel.VERBOSE
-solver = aligator.SolverProxDDP(TOL, mu_init, rho_init, verbose=verbose)
+solver = aligator.SolverProxDDP(TOL, mu_init, verbose=verbose)
 # solver = aligator.SolverFDDP(TOL, verbose=verbose)
 solver.rollout_type = aligator.ROLLOUT_LINEAR
 # solver = aligator.SolverFDDP(TOL, verbose=verbose)

--- a/examples/ur5_croco.py
+++ b/examples/ur5_croco.py
@@ -127,9 +127,8 @@ pb_prox = aligator.croc.convertCrocoddylProblem(problem)
 verbose = aligator.VerboseLevel.VERBOSE
 solver2 = aligator.SolverFDDP(1e-6, verbose=verbose)
 mu_init = 1e-8
-rho_init = 1e-9
 
-# solver2 = aligator.SolverProxDDP(tol / nsteps, mu_init, rho_init, verbose=verbose)
+# solver2 = aligator.SolverProxDDP(tol / nsteps, mu_init, verbose=verbose)
 solver2.setup(pb_prox)
 conv = solver2.run(pb_prox, init_xs, init_us)
 results = solver2.results

--- a/examples/ur5_reach.py
+++ b/examples/ur5_reach.py
@@ -118,12 +118,9 @@ problem = aligator.TrajOptProblem(x0, stages, term_cost=term_cost)
 tol = 1e-7
 
 mu_init = 1e-7
-rho_init = 0.0
 verbose = aligator.VerboseLevel.VERBOSE
 max_iters = 40
-solver = aligator.SolverProxDDP(
-    tol, mu_init, rho_init, max_iters=max_iters, verbose=verbose
-)
+solver = aligator.SolverProxDDP(tol, mu_init, max_iters=max_iters, verbose=verbose)
 solver.rollout_type = aligator.ROLLOUT_NONLINEAR
 solver.sa_strategy = aligator.SA_LINESEARCH
 if args.fddp:

--- a/include/aligator/solvers/proxddp/solver-proxddp.hpp
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hpp
@@ -67,8 +67,6 @@ public:
     Scalar dual_beta = 1.;
     /// Scale factor for the dual proximal penalty.
     Scalar mu_update_factor = 0.01;
-    /// Scale factor for the primal proximal penalty.
-    Scalar rho_update_factor = 1.0;
     /// Constraints AL scaling
     Scalar constraints_al_scale = 100.;
     /// Lower bound on AL parameter
@@ -83,7 +81,6 @@ public:
   Scalar target_tol_ = 1e-6;
 
   Scalar mu_init = 0.01; //< Initial AL parameter
-  Scalar rho_init = 0.;
 
   //// Inertia-correcting heuristic
 
@@ -154,14 +151,11 @@ private:
   /// This is the global parameter: scales may be applied for stagewise
   /// constraints, dynamicals...
   Scalar mu_penal_ = mu_init;
-  /// Primal proximal parameter \f$\rho > 0\f$
-  Scalar rho_penal_ = rho_init;
   /// Linesearch function
   LinesearchType linesearch_;
 
 public:
   SolverProxDDPTpl(const Scalar tol = 1e-6, const Scalar mu_init = 0.01,
-                   const Scalar rho_init = 0.,
                    const std::size_t max_iters = 1000,
                    VerboseLevel verbose = VerboseLevel::QUIET,
                    HessianApprox hess_approx = HessianApprox::GAUSS_NEWTON);
@@ -278,9 +272,6 @@ public:
   }
   ALIGATOR_INLINE Scalar mu_inv() const { return 1. / mu(); }
 
-  /// @copydoc rho_penal_
-  ALIGATOR_INLINE Scalar rho() const { return rho_penal_; }
-
   /// @brief Update primal-dual feedback gains (control, costate, path
   /// multiplier)
   inline void updateGains();
@@ -300,8 +291,6 @@ protected:
   ALIGATOR_INLINE void setAlmPenalty(Scalar new_mu) noexcept {
     mu_penal_ = std::max(new_mu, bcl_params.mu_lower_bound);
   }
-
-  ALIGATOR_INLINE void setRho(Scalar new_rho) noexcept { rho_penal_ = new_rho; }
 
   // See sec. 3.1 of the IPOPT paper [Wächter, Biegler 2006]
   // called before first bwd pass attempt

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -68,11 +68,10 @@ void computeProjectedJacobians(const TrajOptProblemTpl<Scalar> &problem,
 template <typename Scalar>
 SolverProxDDPTpl<Scalar>::SolverProxDDPTpl(const Scalar tol,
                                            const Scalar mu_init,
-                                           const Scalar rho_init,
                                            const std::size_t max_iters,
                                            VerboseLevel verbose,
                                            HessianApprox hess_approx)
-    : target_tol_(tol), mu_init(mu_init), rho_init(rho_init), verbose_(verbose),
+    : target_tol_(tol), mu_init(mu_init), verbose_(verbose),
       hess_approx_(hess_approx), max_iters(max_iters), rollout_max_iters(1),
       filter_(0.0, ls_params.alpha_min, ls_params.max_num_steps),
       linesearch_(ls_params) {
@@ -468,7 +467,6 @@ bool SolverProxDDPTpl<Scalar>::run(const Problem &problem,
   logger.printHeadline();
 
   setAlmPenalty(mu_init);
-  setRho(rho_init);
 
   workspace_.prev_xs = results_.xs;
   workspace_.prev_us = results_.us;
@@ -533,7 +531,6 @@ bool SolverProxDDPTpl<Scalar>::run(const Problem &problem,
         setAlmPenalty(mu_init);
       }
     }
-    rho_penal_ *= bcl_params.rho_update_factor;
 
     inner_tol_ = std::max(inner_tol_, 0.01 * target_tol_);
     prim_tol_ = std::max(prim_tol_, target_tol_);

--- a/tests/python/test_constrained_dynamics.py
+++ b/tests/python/test_constrained_dynamics.py
@@ -258,11 +258,8 @@ def test_constrained_dynamics():
     tol = 1e-5
     mu_init = 0.01
     verbose = aligator.VerboseLevel.VERBOSE
-    rho_init = 0.001
     history_cb = aligator.HistoryCallback()
-    solver = aligator.SolverProxDDP(
-        tol, mu_init, rho_init, verbose=verbose, max_iters=200
-    )
+    solver = aligator.SolverProxDDP(tol, mu_init, verbose=verbose, max_iters=200)
     solver.registerCallback("his", history_cb)
     solver.setup(problem)
     conv = solver.run(problem, xs_init, us_init)

--- a/tests/python/test_example_problem.py
+++ b/tests/python/test_example_problem.py
@@ -110,7 +110,7 @@ class TestClass:
     stage_model = aligator.StageModel(cost, dynmodel)
     tol = 1e-5
     mu_init = 1e-2
-    solver = aligator.SolverProxDDP(tol, mu_init, 0.0)
+    solver = aligator.SolverProxDDP(tol, mu_init)
 
     def test_dyn(self, nsteps):
         dyn_data = self.dynmodel.createData()

--- a/tests/python/test_solver.py
+++ b/tests/python/test_solver.py
@@ -55,7 +55,7 @@ def test_no_node():
     terminal_cost = aligator.CostStack(space, nu)
     problem = aligator.TrajOptProblem(x0, nu, space, terminal_cost)
     solver = aligator.SolverProxDDP(
-        TOL, mu_init, rho_init=0.0, max_iters=MAX_ITER, verbose=aligator.VERBOSE
+        TOL, mu_init, max_iters=MAX_ITER, verbose=aligator.VERBOSE
     )
     solver.setup(problem)
 

--- a/tests/python/test_solver.py
+++ b/tests/python/test_solver.py
@@ -100,7 +100,7 @@ def test_proxddp_lqr(strategy):
 
     tol = 1e-6
     mu_init = 1e-4
-    solver = aligator.SolverProxDDP(tol, mu_init, 0.0, verbose=aligator.VERBOSE)
+    solver = aligator.SolverProxDDP(tol, mu_init, verbose=aligator.VERBOSE)
     solver.setup(problem)
     solver.sa_strategy = strategy
     solver.max_iters = 3


### PR DESCRIPTION
This PR removes the `rho_` parameter of the solver, which used to be the primal proximal regularization parameter but was not used anymore for a while. This is an **API BREAKING** change.