### PR TITLE
Scale the dynamics' AL parameter instead of the constraints, remove deprecated functions, rename `TrajOptProblemTpl::init_condition_` to `init_constraint_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove constraint scalers (including header `core/alm-weights.hpp`) from ProxDDP algorithm ([#214](https://github.com/Simple-Robotics/aligator/pull/214))
 - SolverProxDDP: remove solver parameter `rho_` ([#221](https://github.com/Simple-Robotics/aligator/pull/221))
 - Remove deprecated functions `ConstraintStackTpl::getDims` and `StageModelTpl::dyn_model`
+- Remove `CallbackBaseTpl::post_linesearch_call(boost::any)`
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SolverProxDDP: add dynamics AL parameter scaling
 - Rename `has_dyn_model` -> `hasDynModel` and `is_explicit` -> `isExplicit`
 - Add `cost` (trajectory cost) column to logger
+- `TrajOptProblem`: rename member `init_condition_` to `init_constraint_` (fitting with ctor argument name)
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,11 +24,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Separate centroidal wrench cone and multibody wrench cone costs
 - Add a contact_name item to the CostMap structure
 - Re-define ALM params struct internally to aligator ([#219](https://github.com/Simple-Robotics/aligator/pull/219))
+- SolverProxDDP: add dynamics AL parameter scaling
+- Rename `has_dyn_model` -> `hasDynModel` and `is_explicit` -> `isExplicit`
+- Add `cost` (trajectory cost) column to logger
 
 ### Removed
 
 - Remove constraint scalers (including header `core/alm-weights.hpp`) from ProxDDP algorithm ([#214](https://github.com/Simple-Robotics/aligator/pull/214))
 - SolverProxDDP: remove solver parameter `rho_` ([#221](https://github.com/Simple-Robotics/aligator/pull/221))
+- Remove deprecated functions `ConstraintStackTpl::getDims` and `StageModelTpl::dyn_model`
 
 ### Fixed
 

--- a/bindings/python/include/aligator/python/solvers.hpp
+++ b/bindings/python/include/aligator/python/solvers.hpp
@@ -17,14 +17,13 @@ struct SolverVisitor : bp::def_visitor<SolverVisitor<SolverType>> {
   using CallbackPtr = typename SolverType::CallbackPtr;
   static auto getCallback(const SolverType &obj,
                           const std::string &name) -> CallbackPtr {
-    const auto &cbs = obj.getCallbacks();
-    auto cb = cbs.find(name);
-    if (cb == cbs.end()) {
+    const CallbackPtr &cb = obj.getCallback(name);
+    if (!cb) {
       PyErr_SetString(PyExc_KeyError,
                       fmt::format("Key {} not found.", name).c_str());
       bp::throw_error_already_set();
     }
-    return cb->second;
+    return cb;
   }
 
   template <typename... Args> void visit(bp::class_<Args...> &obj) const {

--- a/bindings/python/include/aligator/python/solvers.hpp
+++ b/bindings/python/include/aligator/python/solvers.hpp
@@ -27,7 +27,7 @@ struct SolverVisitor : bp::def_visitor<SolverVisitor<SolverType>> {
     return cb->second;
   }
 
-  template <typename PyClass> void visit(PyClass &obj) const {
+  template <typename... Args> void visit(bp::class_<Args...> &obj) const {
     obj.def_readwrite("verbose", &SolverType::verbose_,
                       "Verbosity level of the solver.")
         .def_readwrite("max_iters", &SolverType::max_iters,
@@ -37,6 +37,7 @@ struct SolverVisitor : bp::def_visitor<SolverVisitor<SolverType>> {
         .def_readwrite("target_tol", &SolverType::target_tol_,
                        "Target tolerance.")
         .def_readwrite("reg_init", &SolverType::reg_init)
+        .def_readwrite("preg", &SolverType::preg_)
         .def_readwrite("force_initial_condition",
                        &SolverType::force_initial_condition_,
                        "Set x0 to be fixed to the initial condition.")

--- a/bindings/python/src/expose-problem.cpp
+++ b/bindings/python/src/expose-problem.cpp
@@ -52,7 +52,7 @@ void exposeProblem() {
                     "Number of stages in the problem.CostPtr")
       .add_property("x0_init", &TrajOptProblem::getInitState,
                     &TrajOptProblem::setInitState, "Initial state.")
-      .add_property("init_constraint", &TrajOptProblem::init_condition_,
+      .add_property("init_constraint", &TrajOptProblem::init_constraint_,
                     "Get initial state constraint.")
       .def("addTerminalConstraint", &TrajOptProblem::addTerminalConstraint,
            ("self"_a, "constraint"), "Add a terminal constraint.")

--- a/bindings/python/src/expose-solver-fddp.cpp
+++ b/bindings/python/src/expose-solver-fddp.cpp
@@ -77,7 +77,6 @@ void exposeFDDP() {
            "reg_init"_a = 1e-9, "max_iters"_a = 1000)))
       .def_readwrite("reg_min", &SolverFDDP::reg_min_)
       .def_readwrite("reg_max", &SolverFDDP::reg_max_)
-      .def_readwrite("preg", &SolverFDDP::preg_)
       .def(SolverVisitor<SolverFDDP>())
       .def("run", &SolverFDDP::run,
            ("self"_a, "problem", "xs_init", "us_init"));

--- a/bindings/python/src/expose-solver-prox.cpp
+++ b/bindings/python/src/expose-solver-prox.cpp
@@ -122,8 +122,6 @@ void exposeProxDDP() {
                          "Minimum regularization value.")
           .def_readwrite("reg_max", &SolverType::reg_max,
                          "Maximum regularization value.")
-          .def_readwrite("preg", &SolverType::preg_,
-                         "Primal regularization parameter.")
           .def_readwrite("lq_print_detailed", &SolverType::lq_print_detailed)
           .def("updateLQSubproblem", &SolverType::updateLQSubproblem, "self"_a)
           .def("computeCriterion", &SolverType::computeCriterion, "self"_a,

--- a/bindings/python/src/expose-solver-prox.cpp
+++ b/bindings/python/src/expose-solver-prox.cpp
@@ -155,7 +155,7 @@ void exposeProxDDP() {
         ._c(dual_alpha)
         ._c(dual_beta)
         ._c(mu_update_factor)
-        ._c(constraints_al_scale)
+        ._c(dyn_al_scale)
         ._c(mu_lower_bound);
 #undef _c
   }

--- a/bindings/python/src/modelling/expose-dynamics.cpp
+++ b/bindings/python/src/modelling/expose-dynamics.cpp
@@ -43,7 +43,7 @@ void exposeDynamicsBase() {
       .def_readonly("space_next", &DynamicsModel::space_next_)
       .add_property("nx1", &DynamicsModel::nx1)
       .add_property("nx2", &DynamicsModel::nx2)
-      .add_property("is_explicit", &DynamicsModel::is_explicit,
+      .add_property("isExplicit", &DynamicsModel::isExplicit,
                     "Return whether the current model is explicit.")
       .def(CreateDataPolymorphicPythonVisitor<DynamicsModel, PyDynamicsModel>())
       .def(PolymorphicMultiBaseVisitor<DynamicsModel>())

--- a/examples/lqr.py
+++ b/examples/lqr.py
@@ -75,8 +75,7 @@ if args.term_cstr:
     )
 
 # Instantiate a solver separately
-mu_init = 1e-3 if args.bounds else 1e-6
-rho_init = 0.0
+mu_init = 1e-1 if args.bounds else 1e-4
 verbose = aligator.VerboseLevel.VERBOSE
 tol = 1e-8
 solver = aligator.SolverProxDDP(tol, mu_init, verbose=verbose)

--- a/examples/quadrotor_obstacles.py
+++ b/examples/quadrotor_obstacles.py
@@ -296,8 +296,10 @@ def main(args: Args):
                 )
                 stage.addConstraint(floor, constraints.NegativeOrthant())
                 stage.addConstraint(column1, constraints.NegativeOrthant())
-                # column2 = Column(space, nu, center_column2[:2], cyl_radius, quad_radius)
-                # stage.addConstraint(column2, constraints.NegativeOrthant())
+                column2 = Column(
+                    rmodel, space.ndx, nu, center_column2[:2], cyl_radius, quad_radius
+                )
+                stage.addConstraint(column2, constraints.NegativeOrthant())
             prob.addStage(stage)
         if args.term_cstr:
             term_cstr = aligator.StageConstraint(

--- a/examples/quadrotor_obstacles.py
+++ b/examples/quadrotor_obstacles.py
@@ -183,8 +183,8 @@ def main(args: Args):
     space = manifolds.MultibodyPhaseSpace(rmodel)
     ode_dynamics = aligator.dynamics.MultibodyFreeFwdDynamics(space, QUAD_ACT_MATRIX)
 
-    dt = 0.02
-    Tf = 1.0
+    dt = 0.01
+    Tf = 1.8
     nsteps = int(Tf / dt)
     print("nsteps: {:d}".format(nsteps))
 
@@ -322,19 +322,17 @@ def main(args: Args):
     else:
         vizer = None
 
-    tol = 1e-3
-    mu_init = 1e-2
+    tol = 1e-4
+    mu_init = 1.0
     verbose = aligator.VerboseLevel.VERBOSE
     history_cb = aligator.HistoryCallback()
     solver = aligator.SolverProxDDP(tol, mu_init, verbose=verbose)
     if args.fddp:
         solver = aligator.SolverFDDP(tol, verbose=verbose)
-    solver.max_iters = 200
+    solver.max_iters = 400
     solver.registerCallback("his", history_cb)
-    solver.force_initial_condition = False
-    solver.rollout_type = aligator.ROLLOUT_LINEAR
+    solver.bcl_params.dyn_al_scale = 1e-6
     solver.setup(problem)
-    solver.sa_strategy = aligator.SA_LINESEARCH
     solver.run(problem, xs_init, us_init)
 
     results = solver.results
@@ -360,10 +358,6 @@ def main(args: Args):
         plt.colorbar()
         plt.tight_layout()
         return plt.gcf()
-
-    def test_results():
-        assert results.num_iters == 91
-        assert results.traj_cost <= 8.825e-01
 
     if args.obstacles:
         TAG = "quadrotor_obstacles"

--- a/examples/ur10_ballistic.py
+++ b/examples/ur10_ballistic.py
@@ -269,11 +269,12 @@ term_constraint = create_term_constraint(target_pos=target_pos)
 
 problem = aligator.TrajOptProblem(x0, stages, term_cost)
 problem.addTerminalConstraint(term_constraint)
-tol = 1e-3
-mu_init = 1e-5
+tol = 1e-4
+mu_init = 1e-2
 solver = aligator.SolverProxDDP(tol, mu_init, max_iters=300, verbose=aligator.VERBOSE)
 solver.linear_solver_choice = aligator.LQ_SOLVER_PARALLEL
 solver.rollout_type = aligator.ROLLOUT_LINEAR
+solver.sa_strategy = aligator.SA_FILTER
 his_cb = aligator.HistoryCallback()
 solver.setNumThreads(4)
 solver.registerCallback("his", his_cb)

--- a/include/aligator/compat/crocoddyl/action-model-wrap.hpp
+++ b/include/aligator/compat/crocoddyl/action-model-wrap.hpp
@@ -37,7 +37,7 @@ struct ActionModelWrapperTpl : StageModelTpl<Scalar> {
   explicit ActionModelWrapperTpl(
       boost::shared_ptr<CrocActionModel> action_model);
 
-  bool has_dyn_model() const override { return false; }
+  bool hasDynModel() const override { return false; }
 
   void evaluate(const ConstVectorRef &x, const ConstVectorRef &u,
                 const ConstVectorRef &y, Data &data) const override;

--- a/include/aligator/core/callback-base.hpp
+++ b/include/aligator/core/callback-base.hpp
@@ -10,8 +10,6 @@ template <typename Scalar> struct CallbackBaseTpl {
   using Workspace = WorkspaceBaseTpl<Scalar>;
   using Results = ResultsBaseTpl<Scalar>;
   virtual void call(const Workspace &, const Results &) = 0;
-  /// Call this after linesearch.
-  virtual void post_linesearch_call(boost::any) {}
   virtual ~CallbackBaseTpl() = default;
 };
 

--- a/include/aligator/core/constraint.hpp
+++ b/include/aligator/core/constraint.hpp
@@ -58,8 +58,6 @@ template <typename Scalar> struct ConstraintStackTpl {
 
   /// @brief Get the set of dimensions for each constraint in the stack.
   const std::vector<long> &dims() const { return dims_; }
-  /// @copybrief getDims()
-  ALIGATOR_DEPRECATED const std::vector<long> &getDims() const { return dims_; }
 
   long totalDim() const { return total_dim_; }
 

--- a/include/aligator/core/dynamics.hpp
+++ b/include/aligator/core/dynamics.hpp
@@ -34,7 +34,7 @@ struct DynamicsModelTpl : StageFunctionTpl<_Scalar> {
   /// @copybrief space_next_
   const Manifold &space_next() const { return *space_next_; }
   /// @brief Check if this dynamics model is implicit or explicit.
-  virtual bool is_explicit() const { return false; }
+  virtual bool isExplicit() const { return false; }
 
   inline int nx1() const { return space_->nx(); }
   inline int nx2() const { return space_next_->nx(); }

--- a/include/aligator/core/explicit-dynamics.hpp
+++ b/include/aligator/core/explicit-dynamics.hpp
@@ -27,7 +27,7 @@ public:
   using Manifold = ManifoldAbstractTpl<Scalar>;
   using ManifoldPtr = xyz::polymorphic<Manifold>;
 
-  bool is_explicit() const { return true; }
+  bool isExplicit() const { return true; }
 
   /// Constructor requires providing the next state's manifold.
   ExplicitDynamicsModelTpl(const ManifoldPtr &space, const int nu);

--- a/include/aligator/core/solver-util.hpp
+++ b/include/aligator/core/solver-util.hpp
@@ -54,7 +54,7 @@ auto problemInitializeSolution(const TrajOptProblemTpl<Scalar> &problem) {
   // initialize multipliers...
   vs.resize(nsteps + 1);
   lbdas.resize(nsteps + 1);
-  lbdas[0].setZero(problem.init_condition_->nr);
+  lbdas[0].setZero(problem.init_constraint_->nr);
   for (size_t i = 0; i < nsteps; i++) {
     const StageModelTpl<Scalar> &sm = *problem.stages_[i];
     lbdas[i + 1].setZero(sm.ndx2());

--- a/include/aligator/core/stage-model.hpp
+++ b/include/aligator/core/stage-model.hpp
@@ -87,7 +87,7 @@ public:
   /// Whether the stage's dynamics model can be accessed.
   /// This boolean allows flexibility in solvers when dealing
   /// with different frontends e.g. Crocoddyl's API.
-  virtual bool has_dyn_model() const { return true; }
+  virtual bool hasDynModel() const { return true; }
   ALIGATOR_DEPRECATED virtual const Dynamics &dyn_model() const {
     return *dynamics_;
   }

--- a/include/aligator/core/stage-model.hpp
+++ b/include/aligator/core/stage-model.hpp
@@ -88,9 +88,6 @@ public:
   /// This boolean allows flexibility in solvers when dealing
   /// with different frontends e.g. Crocoddyl's API.
   virtual bool hasDynModel() const { return true; }
-  ALIGATOR_DEPRECATED virtual const Dynamics &dyn_model() const {
-    return *dynamics_;
-  }
 
   int nx1() const { return xspace_->nx(); }
   int ndx1() const { return xspace_->ndx(); }

--- a/include/aligator/core/traj-opt-data.hxx
+++ b/include/aligator/core/traj-opt-data.hxx
@@ -11,7 +11,7 @@ namespace aligator {
 
 template <typename Scalar>
 TrajOptDataTpl<Scalar>::TrajOptDataTpl(const TrajOptProblemTpl<Scalar> &problem)
-    : init_data(problem.init_condition_->createData()) {
+    : init_data(problem.init_constraint_->createData()) {
   stage_data.reserve(problem.numSteps());
   for (std::size_t i = 0; i < problem.numSteps(); i++) {
     stage_data.push_back(problem.stages_[i]->createData());

--- a/include/aligator/core/traj-opt-problem.hpp
+++ b/include/aligator/core/traj-opt-problem.hpp
@@ -87,7 +87,7 @@ template <typename _Scalar> struct TrajOptProblemTpl {
   ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
 
   /// Initial condition
-  xyz::polymorphic<UnaryFunction> init_condition_;
+  xyz::polymorphic<UnaryFunction> init_constraint_;
   /// Stages of the control problem.
   std::vector<xyz::polymorphic<StageModel>> stages_;
   /// Terminal cost.

--- a/include/aligator/solvers/fddp/solver-fddp.hpp
+++ b/include/aligator/solvers/fddp/solver-fddp.hpp
@@ -17,9 +17,6 @@
 
 #include <boost/unordered_map.hpp>
 
-/// @brief  A warning for the FDDP module.
-#define ALIGATOR_FDDP_WARNING(msg) ALIGATOR_WARNING("SolverFDDP", msg)
-
 namespace aligator {
 
 /**
@@ -175,7 +172,7 @@ public:
     }
     return keys;
   }
-  auto getCallback(const std::string &name) -> CallbackPtr {
+  CallbackPtr getCallback(const std::string &name) const {
     auto cb = callbacks_.find(name);
     if (cb != end(callbacks_)) {
       return cb->second;

--- a/include/aligator/solvers/fddp/solver-fddp.hxx
+++ b/include/aligator/solvers/fddp/solver-fddp.hxx
@@ -300,7 +300,7 @@ bool SolverFDDPTpl<Scalar>::run(const Problem &problem,
   logger.addColumn(BASIC_KEYS[5]);
   logger.addColumn(BASIC_KEYS[6]);
   logger.addColumn(BASIC_KEYS[7]);
-  logger.addColumn(BASIC_KEYS[8]);
+  logger.addColumn(BASIC_KEYS[9]);
   logger.printHeadline();
 
   // in Crocoddyl, linesearch xs is primed to use problem x0

--- a/include/aligator/solvers/fddp/solver-fddp.hxx
+++ b/include/aligator/solvers/fddp/solver-fddp.hxx
@@ -36,16 +36,17 @@ void SolverFDDPTpl<Scalar>::setup(const Problem &problem) {
       idx_where_constraints.push_back(i);
   }
   if (idx_where_constraints.size() > 0) {
-    ALIGATOR_FDDP_WARNING(
-        fmt::format("problem stages [{}] have constraints, "
-                    "which this solver cannot handle. "
-                    "Please use a penalized cost formulation.\n",
-                    fmt::join(idx_where_constraints, ", ")));
+    ALIGATOR_WARNING("SolverFDDP",
+                     fmt::format("problem stages [{}] have constraints, "
+                                 "which this solver cannot handle. "
+                                 "Please use a penalized cost formulation.\n",
+                                 fmt::join(idx_where_constraints, ", ")));
   }
   if (!problem.term_cstrs_.empty()) {
-    ALIGATOR_FDDP_WARNING("problem has at least one terminal constraint, which "
-                          "this solver cannot "
-                          "handle.\n");
+    ALIGATOR_WARNING("SolverFDDP",
+                     "problem has at least one terminal constraint, which "
+                     "this solver cannot "
+                     "handle.\n");
   }
 }
 

--- a/include/aligator/solvers/proxddp/results.hxx
+++ b/include/aligator/solvers/proxddp/results.hxx
@@ -59,7 +59,7 @@ void ResultsTpl<Scalar>::cycleAppend(const TrajOptProblemTpl<Scalar> &problem,
   vs[nsteps - 1].setZero(sm.nc());
   lams[nsteps].setZero(sm.ndx2());
 
-  lams[0].setZero(problem.init_condition_->nr);
+  lams[0].setZero(problem.init_constraint_->nr);
 
   if (!problem.term_cstrs_.empty()) {
     const int ndx_ter = internal::problem_last_ndx_helper(problem);

--- a/include/aligator/solvers/proxddp/solver-proxddp.hpp
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hpp
@@ -136,8 +136,6 @@ public:
   std::size_t max_al_iters = 100;      //< Maximum number of ALM iterations.
   uint rollout_max_iters;              //< Nonlinear rollout options
 
-  /// Callbacks
-  CallbackMap callbacks_;
   Workspace workspace_;
   Results results_;
   /// LQR subproblem solver
@@ -145,6 +143,8 @@ public:
   Filter filter_;
 
 private:
+  /// Callbacks
+  CallbackMap callbacks_;
   /// Number of threads
   std::size_t num_threads_ = 1;
   /// Dual proximal/ALM penalty parameter \f$\mu\f$
@@ -227,12 +227,10 @@ public:
   /// \{
 
   /// @brief    Add a callback to the solver instance.
-  void registerCallback(const std::string &name, CallbackPtr cb) {
-    callbacks_[name] = cb;
-  }
+  void registerCallback(const std::string &name, CallbackPtr cb);
 
   /// @brief    Remove all callbacks from the instance.
-  void clearCallbacks() noexcept { callbacks_.clear(); }
+  inline void clearCallbacks() noexcept { callbacks_.clear(); }
 
   const CallbackMap &getCallbacks() const { return callbacks_; }
   void removeCallback(const std::string &name) { callbacks_.erase(name); }
@@ -243,7 +241,8 @@ public:
     }
     return keys;
   }
-  auto getCallback(const std::string &name) -> CallbackPtr {
+
+  CallbackPtr getCallback(const std::string &name) const {
     auto cb = callbacks_.find(name);
     if (cb != end(callbacks_)) {
       return cb->second;

--- a/include/aligator/solvers/proxddp/solver-proxddp.hpp
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hpp
@@ -68,7 +68,7 @@ public:
     /// Scale factor for the dual proximal penalty.
     Scalar mu_update_factor = 0.01;
     /// Constraints AL scaling
-    Scalar constraints_al_scale = 100.;
+    Scalar dyn_al_scale = 1e-3;
     /// Lower bound on AL parameter
     Scalar mu_lower_bound = 1e-8; //< Minimum possible penalty parameter.
   };
@@ -266,10 +266,10 @@ public:
                           const std::vector<VectorXs> &lams,
                           const std::vector<VectorXs> &vs);
 
-  ALIGATOR_INLINE Scalar mudyn() const { return mu_penal_; }
-  ALIGATOR_INLINE Scalar mu() const {
-    return bcl_params.constraints_al_scale * mu_penal_;
+  ALIGATOR_INLINE Scalar mudyn() const {
+    return bcl_params.dyn_al_scale * mu_penal_;
   }
+  ALIGATOR_INLINE Scalar mu() const { return mu_penal_; }
   ALIGATOR_INLINE Scalar mu_inv() const { return 1. / mu(); }
 
   /// @brief Update primal-dual feedback gains (control, costate, path

--- a/include/aligator/solvers/proxddp/solver-proxddp.hpp
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hpp
@@ -230,7 +230,7 @@ public:
   void registerCallback(const std::string &name, CallbackPtr cb);
 
   /// @brief    Remove all callbacks from the instance.
-  inline void clearCallbacks() noexcept { callbacks_.clear(); }
+  void clearCallbacks() noexcept { callbacks_.clear(); }
 
   const CallbackMap &getCallbacks() const { return callbacks_; }
   void removeCallback(const std::string &name) { callbacks_.erase(name); }

--- a/include/aligator/solvers/proxddp/solver-proxddp.hpp
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hpp
@@ -299,7 +299,7 @@ protected:
   inline void initializeRegularization() noexcept {
     if (preg_last_ == 0.) {
       // this is the 1st iteration
-      preg_ = reg_init;
+      preg_ = std::max(reg_init, reg_min);
     } else {
       // attempt decrease from last "good" value
       preg_ = std::max(reg_min, preg_last_ * reg_dec_k_);

--- a/include/aligator/solvers/proxddp/solver-proxddp.hpp
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hpp
@@ -278,13 +278,15 @@ public:
 
 protected:
   void updateTolsOnFailure() noexcept {
-    prim_tol_ = prim_tol0 * std::pow(mu_penal_, bcl_params.prim_alpha);
-    inner_tol_ = inner_tol0 * std::pow(mu_penal_, bcl_params.dual_alpha);
+    const Scalar arg = std::min(mu_penal_, 0.99);
+    prim_tol_ = prim_tol0 * std::pow(arg, bcl_params.prim_alpha);
+    inner_tol_ = inner_tol0 * std::pow(arg, bcl_params.dual_alpha);
   }
 
   void updateTolsOnSuccess() noexcept {
-    prim_tol_ = prim_tol_ * std::pow(mu_penal_, bcl_params.prim_beta);
-    inner_tol_ = inner_tol_ * std::pow(mu_penal_, bcl_params.dual_beta);
+    const Scalar arg = std::min(mu_penal_, 0.99);
+    prim_tol_ = prim_tol_ * std::pow(arg, bcl_params.prim_beta);
+    inner_tol_ = inner_tol_ * std::pow(arg, bcl_params.dual_beta);
   }
 
   /// Set dual proximal/ALM penalty parameter.

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -758,6 +758,12 @@ template <typename Scalar> void SolverProxDDPTpl<Scalar>::computeCriterion() {
                math::infty_norm(workspace_.control_dual_infeas));
 }
 
+template <typename Scalar>
+void SolverProxDDPTpl<Scalar>::registerCallback(const std::string &name,
+                                                CallbackPtr cb) {
+  callbacks_.insert_or_assign(name, cb);
+}
+
 template <typename Scalar> void SolverProxDDPTpl<Scalar>::updateLQSubproblem() {
   ALIGATOR_NOMALLOC_SCOPED;
   ALIGATOR_TRACY_ZONE_SCOPED;

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -380,7 +380,7 @@ Scalar SolverProxDDPTpl<Scalar>::tryNonlinearRollout(const Problem &problem,
 
     DynamicsData &dd = *data.dynamics_data;
 
-    if (!stage.has_dyn_model() || stage.dynamics_->is_explicit()) {
+    if (!stage.hasDynModel() || stage.dynamics_->isExplicit()) {
       ExplicitDynData &exp_dd = static_cast<ExplicitDynData &>(dd);
       stage.xspace_next().integrate(exp_dd.xnext_, dyn_slacks[t], xs[t + 1]);
       // at xs[i+1], the dynamics gap = the slack dyn_slack[i].

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -679,6 +679,7 @@ bool SolverProxDDPTpl<Scalar>::innerLoop(const Problem &problem) {
     logger.addEntry("dual_err", results_.dual_infeas);
     logger.addEntry("preg", preg_);
     logger.addEntry("dphi0", dphi0);
+    logger.addEntry("cost", results_.traj_cost_);
     logger.addEntry("merit", phi_new);
     logger.addEntry("ΔM", phi_new - phi0);
     logger.addEntry("aliter", results_.al_iter + 1);

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -682,7 +682,7 @@ bool SolverProxDDPTpl<Scalar>::innerLoop(const Problem &problem) {
     logger.addEntry("merit", phi_new);
     logger.addEntry("ΔM", phi_new - phi0);
     logger.addEntry("aliter", results_.al_iter + 1);
-    logger.addEntry("mu", mudyn());
+    logger.addEntry("mu", mu());
 
     if (alpha_opt <= ls_params.alpha_min) {
       if (preg_ >= reg_max)

--- a/include/aligator/solvers/proxddp/workspace.hxx
+++ b/include/aligator/solvers/proxddp/workspace.hxx
@@ -68,7 +68,7 @@ WorkspaceTpl<Scalar>::WorkspaceTpl(const TrajOptProblemTpl<Scalar> &problem)
   }
 
   // initial condition
-  long nc0 = (long)problem.init_condition_->nr;
+  long nc0 = (long)problem.init_constraint_->nr;
   lqr_problem = LQRProblemType(knots, nc0);
   std::tie(dxs, dus, dvs, dlams) =
       gar::lqrInitializeSolution(lqr_problem); // lqr subproblem variables
@@ -128,7 +128,7 @@ void WorkspaceTpl<Scalar>::cycleAppend(const TrajOptProblemTpl<Scalar> &problem,
   active_constraints[nsteps - 1].setZero(stage.nc());
 
   // initial condition
-  long nc0 = (long)problem.init_condition_->nr;
+  long nc0 = (long)problem.init_constraint_->nr;
   lqr_problem = LQRProblemType(knots, nc0);
   std::tie(dxs, dus, dvs, dlams) =
       gar::lqrInitializeSolution(lqr_problem); // lqr subproblem variables

--- a/include/aligator/utils/forward-dyn.hpp
+++ b/include/aligator/utils/forward-dyn.hpp
@@ -30,7 +30,7 @@ template <typename T> struct forwardDynamics {
     using ExpModel = ExplicitDynamicsModelTpl<T>;
     using ExpData = ExplicitDynamicsDataTpl<T>;
 
-    if (model.is_explicit()) {
+    if (model.isExplicit()) {
       const ExpModel &model_cast = static_cast<const ExpModel &>(model);
       ExpData &data_cast = static_cast<ExpData &>(data);
       run(model_cast, x, u, data_cast, xout, gap);

--- a/include/aligator/utils/logger.hpp
+++ b/include/aligator/utils/logger.hpp
@@ -20,7 +20,7 @@ struct LogColumn {
 };
 
 // log columns names and widths
-static const std::array<LogColumn, 11> BASIC_KEYS = {
+static const std::array<LogColumn, 12> BASIC_KEYS = {
     {{"iter", int_format, 5U},
      {"alpha", sci_format, 10U},
      {"inner_crit", sci_format, 10U},
@@ -28,6 +28,7 @@ static const std::array<LogColumn, 11> BASIC_KEYS = {
      {"dual_err", sci_format, 10U},
      {"preg", sci_format, 10U},
      {"dphi0", sci_format, 11U},
+     {"cost", sci_format, 11U},
      {"merit", sci_format, 11U},
      {"ΔM", sci_format, 11U},
      {"aliter", int_format, 7U},


### PR DESCRIPTION
- also rename some functions
- add `cost` to logger
- rename `TrajOptProblemTpl::init_condition_` member to `TrajOptProblemTpl::init_constraint_` for consistency with ctor

This PR contains **breaking changes** (removed deprecated functions), including when it comes to example behaviour due to the new $\mu$ scaling behaviour.

@edantec 