### PR TITLE
Change formatting of exceptions: variadic macros dispatch to type-erased

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,7 @@ endif()
 
 add_project_dependency(proxsuite-nlp 0.8.0 REQUIRED PKG_CONFIG_REQUIRES "proxsuite-nlp >= 0.8.0")
 
-set(LIB_SOURCES src/utils/logger.cpp)
+set(LIB_SOURCES src/utils/exceptions.cpp src/utils/logger.cpp)
 
 file(
   GLOB_RECURSE LIB_HEADERS

--- a/bindings/python/include/aligator/python/macros.hpp
+++ b/bindings/python/include/aligator/python/macros.hpp
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <type_traits>
-#include <fmt/format.h>
 #include "aligator/utils/exceptions.hpp"
 #include <eigenpy/fwd.hpp>
 
@@ -37,8 +36,7 @@ ret_type suppress_if_void(boost::python::detail::method_result &&o) {
  */
 #define ALIGATOR_PYTHON_OVERRIDE_PURE(ret_type, pyname, ...)                   \
   ALIGATOR_PYTHON_OVERRIDE_IMPL(ret_type, pyname, __VA_ARGS__);                \
-  ALIGATOR_RUNTIME_ERROR(                                                      \
-      fmt::format("Tried to call pure virtual function {:s}.", pyname))
+  ALIGATOR_RUNTIME_ERROR("Tried to call pure virtual function {:s}.", pyname)
 
 /**
  * @def ALIGATOR_PYTHON_OVERRIDE(ret_type, cname, fname, ...)

--- a/gar/include/aligator/gar/lqr-problem.hpp
+++ b/gar/include/aligator/gar/lqr-problem.hpp
@@ -2,6 +2,7 @@
 #pragma once
 
 #include "aligator/math.hpp"
+#include <fmt/format.h>
 
 #include <optional>
 

--- a/gar/include/aligator/gar/lqr-problem.hxx
+++ b/gar/include/aligator/gar/lqr-problem.hxx
@@ -38,11 +38,11 @@ Scalar LQRProblemTpl<Scalar>::evaluate(
     const VectorOfVectors &xs, const VectorOfVectors &us,
     const std::optional<ConstVectorRef> &theta_) const {
   if ((int)xs.size() != horizon() + 1)
-    ALIGATOR_RUNTIME_ERROR(fmt::format(
-        "Wrong size for vector xs (expected {:d}).", horizon() + 1));
+    ALIGATOR_RUNTIME_ERROR("Wrong size for vector xs (expected {:d}).",
+                           horizon() + 1);
   if ((int)us.size() < horizon())
-    ALIGATOR_RUNTIME_ERROR(
-        fmt::format("Wrong size for vector us (expected {:d}).", horizon()));
+    ALIGATOR_RUNTIME_ERROR("Wrong size for vector us (expected {:d}).",
+                           horizon());
 
   if (!isInitialized())
     return 0.;

--- a/gar/include/aligator/gar/lqr-problem.hxx
+++ b/gar/include/aligator/gar/lqr-problem.hxx
@@ -38,11 +38,9 @@ Scalar LQRProblemTpl<Scalar>::evaluate(
     const VectorOfVectors &xs, const VectorOfVectors &us,
     const std::optional<ConstVectorRef> &theta_) const {
   if ((int)xs.size() != horizon() + 1)
-    ALIGATOR_RUNTIME_ERROR("Wrong size for vector xs (expected {:d}).",
-                           horizon() + 1);
+    return 0.;
   if ((int)us.size() < horizon())
-    ALIGATOR_RUNTIME_ERROR("Wrong size for vector us (expected {:d}).",
-                           horizon());
+    return 0.;
 
   if (!isInitialized())
     return 0.;

--- a/gar/include/aligator/gar/utils.hpp
+++ b/gar/include/aligator/gar/utils.hpp
@@ -119,6 +119,9 @@ bool lqrDenseMatrix(const LQRProblemTpl<Scalar> &problem, Scalar mudyn,
   if (!problem.isInitialized())
     return false;
 
+  const uint nrows = lqrNumRows(problem);
+  mat.conservativeResize(nrows, nrows);
+  rhs.conservativeResize(nrows);
   mat.setZero();
 
   uint idx = 0;
@@ -211,7 +214,7 @@ auto lqrDenseMatrix(const LQRProblemTpl<Scalar> &problem, Scalar mudyn,
   VectorXs rhs(nrows);
 
   if (!lqrDenseMatrix(problem, mudyn, mueq, mat, rhs)) {
-    ALIGATOR_RUNTIME_ERROR("Problem was not initialized.");
+    fmt::print("{:s} WARNING! Problem was not initialized.", __FUNCTION__);
   }
   return std::make_pair(mat, rhs);
 }

--- a/include/aligator/core/stage-data.hxx
+++ b/include/aligator/core/stage-data.hxx
@@ -22,11 +22,9 @@ StageDataTpl<Scalar>::StageDataTpl(const StageModel &stage_model)
 template <typename Scalar> void StageDataTpl<Scalar>::checkData() {
   const char msg[] = "StageData integrity check failed.";
   if (cost_data == nullptr)
-    ALIGATOR_RUNTIME_ERROR(
-        fmt::format("{} (cost_data cannot be nullptr)", msg));
+    ALIGATOR_RUNTIME_ERROR("{} (cost_data cannot be nullptr)", msg);
   if (dynamics_data == nullptr)
-    ALIGATOR_RUNTIME_ERROR(
-        fmt::format("{} (dynamics_data cannot be nullptr)", msg));
+    ALIGATOR_RUNTIME_ERROR("{} (dynamics_data cannot be nullptr)", msg);
 }
 
 } // namespace aligator

--- a/include/aligator/core/stage-model.hxx
+++ b/include/aligator/core/stage-model.hxx
@@ -25,9 +25,9 @@ StageModelTpl<Scalar>::StageModelTpl(const PolyCost &cost,
       dynamics_(dynamics) {
 
   if (cost->nu != dynamics->nu) {
-    ALIGATOR_RUNTIME_ERROR(fmt::format("Control dimensions cost.nu ({:d}) and "
-                                       "dynamics.nu ({:d}) are inconsistent.",
-                                       cost->nu, dynamics->nu));
+    ALIGATOR_RUNTIME_ERROR("Control dimensions cost.nu ({:d}) and dynamics.nu "
+                           "({:d}) are inconsistent.",
+                           cost->nu, dynamics->nu);
   }
 }
 
@@ -35,9 +35,9 @@ template <typename Scalar>
 void StageModelTpl<Scalar>::addConstraint(const PolyFunction &func,
                                           const PolyConstraintSet &cstr_set) {
   if (func->nu != this->nu()) {
-    ALIGATOR_RUNTIME_ERROR(fmt::format(
+    ALIGATOR_RUNTIME_ERROR(
         "Function has the wrong dimension for u: got {:d}, expected {:d}",
-        func->nu, this->nu()));
+        func->nu, this->nu());
   }
   constraints_.pushBack(func, cstr_set);
 }

--- a/include/aligator/core/traj-opt-problem.hxx
+++ b/include/aligator/core/traj-opt-problem.hxx
@@ -53,11 +53,11 @@ Scalar TrajOptProblemTpl<Scalar>::evaluate(
   ALIGATOR_TRACY_ZONE_SCOPED_N("TrajOptProblem::evaluate");
   const std::size_t nsteps = numSteps();
   if (xs.size() != nsteps + 1)
-    ALIGATOR_RUNTIME_ERROR(fmt::format(
-        "Wrong size for xs (got {:d}, expected {:d})", xs.size(), nsteps + 1));
+    ALIGATOR_RUNTIME_ERROR("Wrong size for xs (got {:d}, expected {:d})",
+                           xs.size(), nsteps + 1);
   if (us.size() != nsteps)
-    ALIGATOR_RUNTIME_ERROR(fmt::format(
-        "Wrong size for us (got {:d}, expected {:d})", us.size(), nsteps));
+    ALIGATOR_RUNTIME_ERROR("Wrong size for us (got {:d}, expected {:d})",
+                           us.size(), nsteps);
 
   init_constraint_->evaluate(xs[0], *prob_data.init_data);
 
@@ -89,11 +89,11 @@ void TrajOptProblemTpl<Scalar>::computeDerivatives(
   ALIGATOR_TRACY_ZONE_SCOPED_N("TrajOptProblem::computeDerivatives");
   const std::size_t nsteps = numSteps();
   if (xs.size() != nsteps + 1)
-    ALIGATOR_RUNTIME_ERROR(fmt::format(
-        "Wrong size for xs (got {:d}, expected {:d})", xs.size(), nsteps + 1));
+    ALIGATOR_RUNTIME_ERROR("Wrong size for xs (got {:d}, expected {:d})",
+                           xs.size(), nsteps + 1);
   if (us.size() != nsteps)
-    ALIGATOR_RUNTIME_ERROR(fmt::format(
-        "Wrong size for us (got {:d}, expected {:d})", us.size(), nsteps));
+    ALIGATOR_RUNTIME_ERROR("Wrong size for us (got {:d}, expected {:d})",
+                           us.size(), nsteps);
 
   init_constraint_->computeJacobians(xs[0], *prob_data.init_data);
 

--- a/include/aligator/fwd.hpp
+++ b/include/aligator/fwd.hpp
@@ -13,10 +13,19 @@
 #endif
 
 #include "aligator/math.hpp"
+#include "aligator/utils/exceptions.hpp"
 #include "aligator/macros.hpp"
 #include "aligator/eigen-macros.hpp"
 #include "aligator/config.hpp"
 #include "aligator/deprecated.hpp"
+
+#define ALIGATOR_RAISE_IF_NAN(value)                                           \
+  if (::aligator::math::check_value(value))                                    \
+  ALIGATOR_RUNTIME_ERROR("Encountered NaN.\n")
+
+#define ALIGATOR_RAISE_IF_NAN_NAME(value, name)                                \
+  if (::aligator::math::check_value(value))                                    \
+  ALIGATOR_RUNTIME_ERROR("Encountered NaN for variable {:s}\n", name)
 
 /// @brief  Main package namespace.
 namespace aligator {

--- a/include/aligator/math.hpp
+++ b/include/aligator/math.hpp
@@ -4,15 +4,6 @@
 #pragma once
 
 #include <proxsuite-nlp/math.hpp>
-#include "aligator/utils/exceptions.hpp"
-
-#define ALIGATOR_RAISE_IF_NAN(value)                                           \
-  if (::aligator::math::check_value(value))                                    \
-  ALIGATOR_RUNTIME_ERROR("Encountered NaN.\n")
-
-#define ALIGATOR_RAISE_IF_NAN_NAME(value, name)                                \
-  if (::aligator::math::check_value(value))                                    \
-  ALIGATOR_RUNTIME_ERROR("Encountered NaN for variable {:s}\n", name)
 
 #define ALIGATOR_DYNAMIC_TYPEDEFS(Scalar) PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar)
 

--- a/include/aligator/math.hpp
+++ b/include/aligator/math.hpp
@@ -12,8 +12,7 @@
 
 #define ALIGATOR_RAISE_IF_NAN_NAME(value, name)                                \
   if (::aligator::math::check_value(value))                                    \
-  ALIGATOR_RUNTIME_ERROR(                                                      \
-      fmt::format("Encountered NaN for variable {:s}\n", name))
+  ALIGATOR_RUNTIME_ERROR("Encountered NaN for variable {:s}\n", name)
 
 #define ALIGATOR_DYNAMIC_TYPEDEFS(Scalar) PROXSUITE_NLP_DYNAMIC_TYPEDEFS(Scalar)
 

--- a/include/aligator/modelling/costs/log-residual-cost.hxx
+++ b/include/aligator/modelling/costs/log-residual-cost.hxx
@@ -12,9 +12,9 @@ LogResidualCostTpl<Scalar>::LogResidualCostTpl(
     const ConstVectorRef &scale)
     : Base(space, function->nu), barrier_weights_(scale), residual_(function) {
   if (scale.size() != function->nr) {
-    ALIGATOR_RUNTIME_ERROR(fmt::format(
+    ALIGATOR_RUNTIME_ERROR(
         "scale argument dimension ({:d}) != function codimension ({:d})",
-        scale.size(), function->nr));
+        scale.size(), function->nr);
   }
   bool negs = (scale.array() <= 0.0).any();
   if (negs) {

--- a/include/aligator/modelling/costs/quad-costs.hpp
+++ b/include/aligator/modelling/costs/quad-costs.hpp
@@ -121,8 +121,8 @@ protected:
 private:
   static void _check_dim_equal(long n, long m, const std::string &msg = "") {
     if (n != m)
-      ALIGATOR_RUNTIME_ERROR(fmt::format(
-          "Dimensions inconsistent: got {:d} and {:d}{}.\n", n, m, msg));
+      ALIGATOR_RUNTIME_ERROR("Dimensions inconsistent: got {:d} and {:d}{}.\n",
+                             n, m, msg);
   }
 
   void debug_check_dims() const {

--- a/include/aligator/modelling/dynamics/multibody-constraint-fwd.hpp
+++ b/include/aligator/modelling/dynamics/multibody-constraint-fwd.hpp
@@ -25,10 +25,13 @@ struct MultibodyConstraintFwdDynamicsTpl : ODEAbstractTpl<_Scalar> {
   using BaseData = ContinuousDynamicsDataTpl<Scalar>;
   using ContDataAbstract = ContinuousDynamicsDataTpl<Scalar>;
   using Data = MultibodyConstraintFwdDataTpl<Scalar>;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   using RigidConstraintModelVector = PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(
-      pinocchio::RigidConstraintModel);
+      pinocchio::RigidConstraintModelTpl<Scalar>);
   using RigidConstraintDataVector =
       PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(pinocchio::RigidConstraintData);
+#pragma GCC diagnostic pop
   using ProxSettings = pinocchio::ProximalSettingsTpl<Scalar>;
   using Manifold = proxsuite::nlp::MultibodyPhaseSpace<Scalar>;
 
@@ -59,8 +62,12 @@ struct MultibodyConstraintFwdDataTpl : ContinuousDynamicsDataTpl<Scalar> {
   using VectorXs = typename math_types<Scalar>::VectorXs;
   using MatrixXs = typename math_types<Scalar>::MatrixXs;
   using PinDataType = pinocchio::DataTpl<Scalar>;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+  using RigidConstraintData = pinocchio::RigidConstraintDataTpl<Scalar>;
+#pragma GCC diagnostic pop
   using RigidConstraintDataVector =
-      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(pinocchio::RigidConstraintData);
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintData);
 
   VectorXs tau_;
   MatrixXs dtau_dx_;

--- a/include/aligator/modelling/dynamics/multibody-constraint-fwd.hxx
+++ b/include/aligator/modelling/dynamics/multibody-constraint-fwd.hxx
@@ -37,9 +37,12 @@ void MultibodyConstraintFwdDynamicsTpl<Scalar>::forward(const ConstVectorRef &x,
   const auto q = x.head(nq);
   const auto v = x.segment(nq, nv);
   d.xdot_.head(nv) = v;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   d.xdot_.segment(nv, nv) = pinocchio::constraintDynamics(
       model, d.pin_data_, q, v, d.tau_, constraint_models_, d.constraint_datas_,
       d.settings);
+#pragma GCC diagnostic pop
 }
 
 template <typename Scalar>
@@ -49,8 +52,11 @@ void MultibodyConstraintFwdDynamicsTpl<Scalar>::dForward(const ConstVectorRef &,
   Data &d = static_cast<Data &>(data);
   const pinocchio::ModelTpl<Scalar> &model = space_.getModel();
   const int nv = model.nv;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   pinocchio::computeConstraintDynamicsDerivatives(
       model, d.pin_data_, constraint_models_, d.constraint_datas_, d.settings);
+#pragma GCC diagnostic pop
   d.Jx_.bottomRows(nv).leftCols(nv) = d.pin_data_.ddq_dq;
   d.Jx_.bottomRows(nv).rightCols(nv) = d.pin_data_.ddq_dv;
   d.Ju_.bottomRows(nv) = d.pin_data_.ddq_dtau * d.dtau_du_;
@@ -73,12 +79,14 @@ MultibodyConstraintFwdDataTpl<Scalar>::MultibodyConstraintFwdDataTpl(
 
   const pinocchio::ModelTpl<Scalar> &model = cont_dyn.space_.getModel();
   pin_data_ = PinDataType(model);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   pinocchio::initConstraintDynamics(model, pin_data_,
                                     cont_dyn.constraint_models_);
+#pragma GCC diagnostic pop
   for (auto cm = std::begin(cont_dyn.constraint_models_);
        cm != std::end(cont_dyn.constraint_models_); ++cm) {
-    constraint_datas_.push_back(
-        pinocchio::RigidConstraintDataTpl<Scalar, 0>(*cm));
+    constraint_datas_.emplace_back(*cm);
   }
   this->Jx_.topRightCorner(model.nv, model.nv).setIdentity();
 }

--- a/include/aligator/solvers/fddp/solver-fddp.hxx
+++ b/include/aligator/solvers/fddp/solver-fddp.hxx
@@ -37,11 +37,10 @@ void SolverFDDPTpl<Scalar>::setup(const Problem &problem) {
       idx_where_constraints.push_back(i);
   }
   if (idx_where_constraints.size() > 0) {
-    ALIGATOR_WARNING("SolverFDDP",
-                     fmt::format("problem stages [{}] have constraints, "
-                                 "which this solver cannot handle. "
-                                 "Please use a penalized cost formulation.\n",
-                                 fmt::join(idx_where_constraints, ", ")));
+    ALIGATOR_WARNING(
+        "SolverFDDP",
+        "Some problem stages have constraints, which this solver cannot "
+        "handle. Please use a penalized cost formulation.\n");
   }
   if (!problem.term_cstrs_.empty()) {
     ALIGATOR_WARNING("SolverFDDP",

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -424,10 +424,9 @@ bool SolverProxDDPTpl<Scalar>::run(const Problem &problem,
     ALIGATOR_RUNTIME_ERROR("workspace and results were not allocated yet!");
   }
   if (mu_init < bcl_params.mu_lower_bound) {
-    ALIGATOR_WARNING(
-        "SolverProxDDP",
-        fmt::format("Initial value of mu_init < mu_lower_bound ({:.3g})",
-                    bcl_params.mu_lower_bound));
+    ALIGATOR_WARNING("SolverProxDDP",
+                     "Initial value of mu_init < mu_lower_bound ({:.3g})",
+                     bcl_params.mu_lower_bound);
     setAlmPenalty(mu_init);
   }
 

--- a/include/aligator/utils/exceptions.hpp
+++ b/include/aligator/utils/exceptions.hpp
@@ -1,25 +1,45 @@
 #pragma once
 
 #include <stdexcept>
-#include <fmt/color.h>
+#include <fmt/base.h>
 
-#define ALIGATOR_RUNTIME_ERROR(msg)                                            \
+#define ALIGATOR_RUNTIME_ERROR(...)                                            \
   throw aligator::RuntimeError(                                                \
-      fmt::format("{}({}): {}", __FILE__, __LINE__, msg))
+      detail::exception_msg(__FILE__, __LINE__, __VA_ARGS__))
 
 #define ALIGATOR_DOMAIN_ERROR(msg)                                             \
-  throw std::domain_error(fmt::format("{}({}): {}", __FILE__, __LINE__, msg))
+  throw std::domain_error(detail::exception_msg(__FILE__, __LINE__, msg))
 
-#define ALIGATOR_WARNING(loc, msg)                                             \
-  fmt::print(fmt::fg(fmt::color::yellow), "[{}] {}: {}", loc, __FUNCTION__,    \
-             msg);
+#define ALIGATOR_WARNING(loc, ...)                                             \
+  detail::warning_call(loc, __FUNCTION__, __VA_ARGS__)
 
 namespace aligator {
+namespace detail {
+void warning_impl(const char *loc, const char *fun, fmt::string_view fstr,
+                  fmt::format_args args);
+template <typename... T>
+void warning_call(const char *loc, const char *fun,
+                  fmt::format_string<T...> fstr, T &&...args) {
+  warning_impl(loc, fun, fstr, fmt::make_format_args(args...));
+}
+template <typename T>
+void warning_call(const char *loc, const char *fun, T &&msg) {
+  warning_impl(loc, fun, msg, {});
+}
+
+std::string exception_msg_impl(const char *filename, int lineno,
+                               fmt::string_view fstr, fmt::format_args args);
+template <typename... T>
+std::string exception_msg(const char *filename, int lineno,
+                          fmt::format_string<T...> fstr, T &&...args) {
+  return exception_msg_impl(filename, lineno, fstr,
+                            fmt::make_format_args(args...));
+}
+} // namespace detail
 
 class RuntimeError : public std::runtime_error {
 public:
-  explicit RuntimeError(const std::string &what = "")
-      : std::runtime_error(what) {}
+  explicit RuntimeError(const std::string &what) : std::runtime_error(what) {}
 };
 
 } // namespace aligator

--- a/include/aligator/utils/exceptions.hpp
+++ b/include/aligator/utils/exceptions.hpp
@@ -4,14 +4,15 @@
 #include <fmt/base.h>
 
 #define ALIGATOR_RUNTIME_ERROR(...)                                            \
-  throw aligator::RuntimeError(                                                \
-      detail::exception_msg(__FILE__, __LINE__, __VA_ARGS__))
+  throw ::aligator::RuntimeError(                                              \
+      ::aligator::detail::exception_msg(__FILE__, __LINE__, __VA_ARGS__))
 
 #define ALIGATOR_DOMAIN_ERROR(msg)                                             \
-  throw std::domain_error(detail::exception_msg(__FILE__, __LINE__, msg))
+  throw std::domain_error(                                                     \
+      ::aligator::detail::exception_msg(__FILE__, __LINE__, msg))
 
 #define ALIGATOR_WARNING(loc, ...)                                             \
-  detail::warning_call(loc, __FUNCTION__, __VA_ARGS__)
+  ::aligator::detail::warning_call(loc, __FUNCTION__, __VA_ARGS__)
 
 namespace aligator {
 namespace detail {

--- a/include/aligator/utils/rollout.hpp
+++ b/include/aligator/utils/rollout.hpp
@@ -65,10 +65,9 @@ void rollout(
   xout.resize(N + 1);
   xout[0] = x0;
   if (dyn_models.size() != N) {
-    ALIGATOR_RUNTIME_ERROR(
-        fmt::format("Number of controls ({}) should be the same as number of "
-                    "dynamical models ({})!",
-                    N, dyn_models.size()));
+    ALIGATOR_RUNTIME_ERROR("Number of controls ({:d}) should be the same as "
+                           "number of dynamical models ({:d})!",
+                           N, dyn_models.size());
   }
 
   for (std::size_t i = 0; i < N; i++) {

--- a/src/utils/exceptions.cpp
+++ b/src/utils/exceptions.cpp
@@ -1,0 +1,19 @@
+#include "aligator/utils/exceptions.hpp"
+#include <fmt/color.h>
+
+namespace aligator {
+namespace detail {
+void warning_impl(const char *loc, const char *fun, fmt::string_view fstr,
+                  fmt::format_args args) {
+  const auto ts = fmt::fg(fmt::color::yellow);
+  fmt::print(ts, "[Warning] {:s}: {:s}: {}", loc, fun,
+             fmt::vformat(fstr, args));
+}
+
+std::string exception_msg_impl(const char *filename, int lineno,
+                               fmt::string_view fstr, fmt::format_args args) {
+  return fmt::format("{:s}({:d}): {}", filename, lineno,
+                     fmt::vformat(fstr, args));
+}
+} // namespace detail
+} // namespace aligator


### PR DESCRIPTION
Change formatting of exceptions: variadic macros dispatch to type-erased

formatting function

+ Make ALIGATOR_RUNTIME_ERROR, ALIGATOR_WARNING to variadic macros
+ Calling either macro does not require including fmt/format.h
+ Change include of fmt/color.h to fmt/base.h in exceptions.h (reduces
  size of include)
+ Add src/utils/exceptions.cpp

Do not include aligator/utils/exceptions.hpp in math.hpp

+ move include to fwd.hpp header
+ remove use of exception macros in gar
+ move math exceptions to fwd.hpp

[python] macros.hpp : remove include of fmt/format.h (use new variadic macro)

Fix macros

[modelling/dynamics] MultibodyConstraintFwd: suppress warnings from Pinocchio deprecations
