### PR TITLE
Change from deprecated `ConstraintSetBase<T>` to `ConstraintSetTpl<T>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change uses of `ConstraintSetBase` template class to `ConstraintSetTpl` (following changes in proxsuite-nlp 0.9.0) ([#223](https://github.com/Simple-Robotics/aligator/pull/233))
+
 ## [0.9.0] - 2024-10-11
 
 ### Added

--- a/examples/clqr.cpp
+++ b/examples/clqr.cpp
@@ -78,7 +78,7 @@ int main() {
   if (terminal) {
     auto xf = VectorXd::Ones(nx);
     auto func = StateErrorResidualTpl<double>(space, nu, xf);
-    problem.addTerminalConstraint({func, EqualityConstraint()});
+    problem.addTerminalConstraint(func, EqualityConstraint());
   }
 
   const double tol = 1e-6;

--- a/include/aligator/context.hpp
+++ b/include/aligator/context.hpp
@@ -18,7 +18,7 @@ using UnaryFunction = UnaryFunctionTpl<Scalar>;
 using StageFunctionData = StageFunctionDataTpl<Scalar>;
 using StageConstraint ALIGATOR_DEPRECATED = StageConstraintTpl<Scalar>;
 
-using ConstraintSet = ConstraintSetBase<Scalar>;
+using ConstraintSet = ConstraintSetTpl<Scalar>;
 
 using CostBase ALIGATOR_DEPRECATED_MESSAGE(
     "Use the CostAbstract typedef instead.") = CostAbstractTpl<Scalar>;

--- a/include/aligator/core/constraint.hpp
+++ b/include/aligator/core/constraint.hpp
@@ -14,14 +14,14 @@ namespace aligator {
 /// constraint.
 template <typename Scalar> struct ALIGATOR_DEPRECATED StageConstraintTpl {
   xyz::polymorphic<StageFunctionTpl<Scalar>> func;
-  xyz::polymorphic<ConstraintSetBase<Scalar>> set;
+  xyz::polymorphic<ConstraintSetTpl<Scalar>> set;
 };
 
 /// @brief Convenience class to manage a stack of constraints.
 template <typename Scalar> struct ConstraintStackTpl {
   ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
   using PolyFunc = xyz::polymorphic<StageFunctionTpl<Scalar>>;
-  using PolySet = xyz::polymorphic<ConstraintSetBase<Scalar>>;
+  using PolySet = xyz::polymorphic<ConstraintSetTpl<Scalar>>;
 
   ConstraintStackTpl() : indices_({0}) {};
   ConstraintStackTpl(const ConstraintStackTpl &) = default;

--- a/include/aligator/core/stage-model.hpp
+++ b/include/aligator/core/stage-model.hpp
@@ -31,7 +31,7 @@ public:
   using Dynamics = DynamicsModelTpl<Scalar>;
   using PolyDynamics = xyz::polymorphic<Dynamics>;
   using PolyFunction = xyz::polymorphic<StageFunctionTpl<Scalar>>;
-  using PolyConstraintSet = xyz::polymorphic<ConstraintSetBase<Scalar>>;
+  using PolyConstraintSet = xyz::polymorphic<ConstraintSetTpl<Scalar>>;
   using Cost = CostAbstractTpl<Scalar>;
   using PolyCost = xyz::polymorphic<Cost>;
   using Data = StageDataTpl<Scalar>;

--- a/include/aligator/core/traj-opt-problem.hpp
+++ b/include/aligator/core/traj-opt-problem.hpp
@@ -28,7 +28,7 @@ template <typename _Scalar> struct TrajOptProblemTpl {
   using Data = TrajOptDataTpl<Scalar>;
   using Manifold = ManifoldAbstractTpl<Scalar>;
   using CostAbstract = CostAbstractTpl<Scalar>;
-  using ConstraintSet = ConstraintSetBase<Scalar>;
+  using ConstraintSet = ConstraintSetTpl<Scalar>;
   using StateErrorResidual = StateErrorResidualTpl<Scalar>;
 
   /**

--- a/include/aligator/fwd.hpp
+++ b/include/aligator/fwd.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <proxsuite-nlp/fwd.hpp>
+#include <proxsuite-nlp/config.hpp>
 
 #ifdef ALIGATOR_WITH_PINOCCHIO
 #include <pinocchio/config.hpp>
@@ -33,7 +34,12 @@ namespace aligator {
 
 // NOLINTBEGIN(misc-unused-using-decls)
 
-using proxsuite::nlp::ConstraintSetBase;
+#if PROXSUITE_NLP_VERSION_AT_LEAST(0, 9, 0)
+using proxsuite::nlp::ConstraintSetTpl;
+#else
+template <typename T>
+using ConstraintSetTpl = proxsuite::nlp::ConstraintSetBase<T>;
+#endif
 using proxsuite::nlp::ManifoldAbstractTpl;
 // Use the math_types template from proxsuite-nlp.
 using proxsuite::nlp::VerboseLevel;

--- a/include/aligator/solvers/proxddp/solver-proxddp.hpp
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hpp
@@ -48,7 +48,7 @@ public:
   using CallbackPtr = shared_ptr<CallbackBaseTpl<Scalar>>;
   using CallbackMap = boost::unordered_map<std::string, CallbackPtr>;
   using ConstraintStack = ConstraintStackTpl<Scalar>;
-  using CstrSet = ConstraintSetBase<Scalar>;
+  using CstrSet = ConstraintSetTpl<Scalar>;
   using TrajOptData = TrajOptDataTpl<Scalar>;
   using LinesearchOptions = typename Linesearch<Scalar>::Options;
   using LinesearchType = proxsuite::nlp::ArmijoLinesearch<Scalar>;

--- a/include/aligator/solvers/proxddp/workspace.hpp
+++ b/include/aligator/solvers/proxddp/workspace.hpp
@@ -13,7 +13,7 @@ namespace aligator {
 
 template <typename Scalar>
 auto getConstraintProductSet(const ConstraintStackTpl<Scalar> &constraints) {
-  std::vector<xyz::polymorphic<ConstraintSetBase<Scalar>>> components;
+  std::vector<xyz::polymorphic<ConstraintSetTpl<Scalar>>> components;
   for (size_t i = 0; i < constraints.size(); i++) {
     components.push_back(constraints.sets[i]);
   }


### PR DESCRIPTION
This follows changes and deprecations in [the latest proxsuite-nlp release](https://github.com/Simple-Robotics/proxsuite-nlp/releases/tag/v0.9.0).
