### PR TITLE
Fixes to ProxDDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `SolverProxDDP`: add temporary vectors for linesearch
+- `SolverProxDDP`: remove exceptions from `computeMultipliers()`, return a bool flag
 - `SolverProxDDP`: Rename `maxRefinementSteps_` and `refinementThreshold_` to snake-case
 - `SolverProxDDP`: make `linesearch_` public
 - Change uses of `ConstraintSetBase` template class to `ConstraintSetTpl` (following changes in proxsuite-nlp 0.9.0) ([#223](https://github.com/Simple-Robotics/aligator/pull/233))

--- a/include/aligator/core/lagrangian.hpp
+++ b/include/aligator/core/lagrangian.hpp
@@ -19,57 +19,65 @@ template <typename Scalar> struct LagrangianDerivatives {
   static void compute(const TrajOptProblem &problem, const TrajOptData &pd,
                       const std::vector<VectorXs> &lams,
                       const std::vector<VectorXs> &vs,
-                      std::vector<VectorXs> &Lxs, std::vector<VectorXs> &Lus) {
-    using ConstraintStack = ConstraintStackTpl<Scalar>;
-    using StageFunctionData = StageFunctionDataTpl<Scalar>;
-    using DynamicsData = DynamicsDataTpl<Scalar>;
-    using CostData = CostDataAbstractTpl<Scalar>;
-    using StageModel = StageModelTpl<Scalar>;
-    using StageData = StageDataTpl<Scalar>;
-    const std::size_t nsteps = problem.numSteps();
+                      std::vector<VectorXs> &Lxs, std::vector<VectorXs> &Lus);
+};
 
-    ALIGATOR_TRACY_ZONE_SCOPED_N("LagrangianDerivatives::compute");
-    ALIGATOR_NOMALLOC_SCOPED;
+template <typename Scalar>
+void LagrangianDerivatives<Scalar>::compute(const TrajOptProblem &problem,
+                                            const TrajOptData &pd,
+                                            const std::vector<VectorXs> &lams,
+                                            const std::vector<VectorXs> &vs,
+                                            std::vector<VectorXs> &Lxs,
+                                            std::vector<VectorXs> &Lus) {
+  using ConstraintStack = ConstraintStackTpl<Scalar>;
+  using StageFunctionData = StageFunctionDataTpl<Scalar>;
+  using DynamicsData = DynamicsDataTpl<Scalar>;
+  using CostData = CostDataAbstractTpl<Scalar>;
+  using StageModel = StageModelTpl<Scalar>;
+  using StageData = StageDataTpl<Scalar>;
+  const std::size_t nsteps = problem.numSteps();
 
-    math::setZero(Lxs);
-    math::setZero(Lus);
+  ALIGATOR_TRACY_ZONE_SCOPED_N("LagrangianDerivatives::compute");
+  ALIGATOR_NOMALLOC_SCOPED;
 
-    // initial condition
-    const StageFunctionData &init_cond = *pd.init_data;
-    Lxs[0].noalias() = init_cond.Jx_.transpose() * lams[0];
+  math::setZero(Lxs);
+  math::setZero(Lus);
 
-    for (std::size_t i = 0; i < nsteps; i++) {
-      const StageModel &sm = *problem.stages_[i];
-      const StageData &sd = *pd.stage_data[i];
-      const ConstraintStack &stack = sm.constraints_;
-      const DynamicsData &dd = *sd.dynamics_data;
-      Lxs[i].noalias() +=
-          sd.cost_data->Lx_ + dd.Jx_.transpose() * lams[i + 1]; // [1] eqn. 24c
-      Lus[i].noalias() =
-          sd.cost_data->Lu_ + dd.Ju_.transpose() * lams[i + 1]; // [1] eqn. 24b
+  // initial condition
+  const StageFunctionData &init_cond = *pd.init_data;
+  Lxs[0].noalias() = init_cond.Jx_.transpose() * lams[0];
 
-      BlkView v_(vs[i], stack.dims());
-      for (std::size_t j = 0; j < stack.size(); j++) {
-        const StageFunctionData &cd = *sd.constraint_data[j];
-        Lxs[i].noalias() += cd.Jx_.transpose() * v_[j]; // [1] eqn. 24c
-        Lus[i].noalias() += cd.Ju_.transpose() * v_[j]; // [1] eqn. 24b
-      }
+  for (std::size_t i = 0; i < nsteps; i++) {
+    const StageModel &sm = *problem.stages_[i];
+    const StageData &sd = *pd.stage_data[i];
+    const ConstraintStack &stack = sm.constraints_;
+    const DynamicsData &dd = *sd.dynamics_data;
+    Lxs[i].noalias() +=
+        sd.cost_data->Lx_ + dd.Jx_.transpose() * lams[i + 1]; // [1] eqn. 24c
+    Lus[i].noalias() =
+        sd.cost_data->Lu_ + dd.Ju_.transpose() * lams[i + 1]; // [1] eqn. 24b
 
-      Lxs[i + 1].noalias() = dd.Jy_.transpose() * lams[i + 1]; // [1] eqn. 24b
+    BlkView v_(vs[i], stack.dims());
+    for (std::size_t j = 0; j < stack.size(); j++) {
+      const StageFunctionData &cd = *sd.constraint_data[j];
+      Lxs[i].noalias() += cd.Jx_.transpose() * v_[j]; // [1] eqn. 24c
+      Lus[i].noalias() += cd.Ju_.transpose() * v_[j]; // [1] eqn. 24b
     }
 
-    // terminal node
-    {
-      const CostData &cdterm = *pd.term_cost_data;
-      Lxs[nsteps] += cdterm.Lx_;
-      const ConstraintStack &stack = problem.term_cstrs_;
-      BlkView vN(vs[nsteps], stack.dims());
-      for (std::size_t j = 0; j < stack.size(); j++) {
-        const StageFunctionData &cd = *pd.term_cstr_data[j];
-        Lxs[nsteps].noalias() += cd.Jx_.transpose() * vN[j];
-      }
+    Lxs[i + 1].noalias() = dd.Jy_.transpose() * lams[i + 1]; // [1] eqn. 24b
+  }
+
+  // terminal node
+  {
+    const CostData &cdterm = *pd.term_cost_data;
+    Lxs[nsteps] += cdterm.Lx_;
+    const ConstraintStack &stack = problem.term_cstrs_;
+    BlkView vN(vs[nsteps], stack.dims());
+    for (std::size_t j = 0; j < stack.size(); j++) {
+      const StageFunctionData &cd = *pd.term_cstr_data[j];
+      Lxs[nsteps].noalias() += cd.Jx_.transpose() * vN[j];
     }
   }
-};
+}
 
 } // namespace aligator

--- a/include/aligator/solvers/proxddp/solver-proxddp.hpp
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hpp
@@ -277,7 +277,8 @@ public:
   /// Compute the merit function and stopping criterion dual terms:
   /// first-order Lagrange multiplier estimates, shifted and
   /// projected constraints.
-  void computeMultipliers(const Problem &problem,
+  /// @return bool: whether the op succeeded.
+  bool computeMultipliers(const Problem &problem,
                           const std::vector<VectorXs> &lams,
                           const std::vector<VectorXs> &vs);
 

--- a/include/aligator/solvers/proxddp/solver-proxddp.hpp
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hpp
@@ -7,7 +7,6 @@
 #include "aligator/core/filter.hpp"
 #include "aligator/core/callback-base.hpp"
 #include "aligator/core/enums.hpp"
-#include "aligator/threads.hpp"
 #include "aligator/utils/logger.hpp"
 #include "aligator/gar/riccati-base.hpp"
 
@@ -171,16 +170,7 @@ public:
                    HessianApprox hess_approx = HessianApprox::GAUSS_NEWTON);
 
   inline std::size_t getNumThreads() const { return num_threads_; }
-  void setNumThreads(const std::size_t num_threads) {
-    if (linearSolver_) {
-      ALIGATOR_WARNING(
-          "SolverProxDDP",
-          "Linear solver already set: setNumThreads() should be called before "
-          "you call setup() if you want to use the parallel linear solver.\n");
-    }
-    num_threads_ = num_threads;
-    omp::set_default_options(num_threads);
-  }
+  void setNumThreads(const std::size_t num_threads);
 
   Scalar getDualTolerance() const { return target_dual_tol_; }
   /// Manually set desired dual feasibility tolerance.

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -534,9 +534,9 @@ bool SolverProxDDPTpl<Scalar>::run(const Problem &problem,
         break;
       }
     } else {
-      setAlmPenalty(mu_penal_inv_ * bcl_params.mu_update_factor);
+      setAlmPenalty(mu_penal_ * bcl_params.mu_update_factor);
       updateTolsOnFailure();
-      if (math::scalar_close(mu_penal_inv_, bcl_params.mu_lower_bound)) {
+      if (math::scalar_close(mu_penal_, bcl_params.mu_lower_bound)) {
         // reset penalty to initial value
         setAlmPenalty(mu_init);
       }

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -512,7 +512,6 @@ bool SolverProxDDPTpl<Scalar>::run(const Problem &problem,
       al_iter++;
       break;
     }
-    linesearch_.reset();
 
     // accept primal updates
     workspace_.prev_xs = results_.xs;

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -6,6 +6,7 @@
 #include "solver-proxddp.hpp"
 #include "merit-function.hpp"
 #include "aligator/core/lagrangian.hpp"
+#include "aligator/threads.hpp"
 #include "aligator/utils/forward-dyn.hpp"
 
 #include "aligator/gar/proximal-riccati.hpp"
@@ -79,6 +80,17 @@ SolverProxDDPTpl<Scalar>::SolverProxDDPTpl(const Scalar tol,
   ls_params.interp_type = proxsuite::nlp::LSInterpolation::CUBIC;
 }
 
+template <typename Scalar>
+void SolverProxDDPTpl<Scalar>::setNumThreads(const std::size_t num_threads) {
+  if (linearSolver_) {
+    ALIGATOR_WARNING(
+        "SolverProxDDP",
+        "Linear solver already set: setNumThreads() should be called before "
+        "you call setup() if you want to use the parallel linear solver.\n");
+  }
+  num_threads_ = num_threads;
+  omp::set_default_options(num_threads);
+}
 // [1] Section IV. Proximal Differential Dynamic Programming
 // C. Forward pass
 template <typename Scalar>


### PR DESCRIPTION
This PR implements a bunch of changes to ProxDDP.


+ lagrangian.hpp : move def out-of-line
+ [solvers/proxddp] have computeMultipliers() return a bool flag
+ [solvers/proxddp] add tmp vectors for linear search
+ [solvers/proxddp] Fix 'else' branch of BCL
+ [solvers/proxddp] move impl of setNumThreads to .hxx

The fix for the 'else' branch of BCL is **critical** and fixes a mistake introduced here: https://github.com/Simple-Robotics/aligator/blame/ae8d331b8db0a7dc53308ad47abf96a7be53b53f/include/aligator/solvers/proxddp/solver-proxddp.hxx#L511-L513 by https://github.com/Simple-Robotics/aligator/commit/755ca6507759dcdc7c723aaa447a9a2408861929

