### PR TITLE
Fix build instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ It's used by our CI agent so you have the guarantee to get the right dependencie
 Run the following command to install dependencies, configure, build and test the project:
 
 ```bash
-pixi run test
+pixi run -e all test
 ```
 
 The project will be built in the `build` directory.


### PR DESCRIPTION
Since aligator doesn't build without pinocchio for now (https://github.com/Simple-Robotics/aligator/issues/241), this PR change build instruction to build with pinocchio support.