### PR TITLE
[cmake] Rework how translation units (examples/benchmarks) defined using cmake_parse_arguments()

### DIFF
--- a/.gersemirc
+++ b/.gersemirc
@@ -1,4 +1,4 @@
-definitions: [./CMakeLists.txt, ./bindings, ./cmake, ./examples, ./tests]
+definitions: [./CMakeLists.txt, ./bench, ./bindings, ./cmake, ./examples, ./tests]
 line_length: 80
 indent: 2
 warn_about_unknown_commands: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -288,6 +288,7 @@ if(BUILD_PYTHON_INTERFACE)
   set(${PYLIB_NAME}_INSTALL_DIR ${PYTHON_SITELIB}/${PROJECT_NAME})
 endif()
 
+# Without template instantiation, library only compiles exceptions and logging.
 set(LIB_SOURCES src/utils/exceptions.cpp src/utils/logger.cpp)
 
 file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,29 +469,37 @@ add_subdirectory(bindings)
 
 # benchmarks, examples, and tests
 
-macro(create_ex_or_bench is_bench exfile exname)
+macro(create_ex_or_bench exfile exname)
+  cmake_parse_arguments(arg_ex "BENCHMARK" "" "DEPENDENCIES" ${ARGN})
+
   add_executable(${exname} ${exfile})
-  if(${is_bench})
-    set(ex_type "bench")
+  if(${arg_ex_BENCHMARK})
+    set(ex_type "benchmark")
   else()
     set(ex_type "example")
   endif()
-  message(STATUS "Adding cpp ${ex_type} ${exname}")
+  message(STATUS "Adding cpp ${ex_type} ${exname} (${exfile})")
   set_target_properties(${exname} PROPERTIES LINKER_LANGUAGE CXX)
   set_standard_output_directory(${exname})
   target_include_directories(${exname} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
 
-  target_link_libraries(${exname} PUBLIC ${PROJECT_NAME})
+  target_link_libraries(
+    ${exname}
+    PRIVATE ${PROJECT_NAME} ${arg_ex_DEPENDENCIES}
+  )
+  if(${arg_ex_BENCHMARK})
+    target_link_libraries(${exname} PRIVATE benchmark::benchmark)
+  endif()
+  if(DEFINED arg_ex_DEPENDENCIES)
+    message("   Dependencies:")
+    foreach(_dep ${arg_ex_DEPENDENCIES})
+      message("     ${_dep}")
+    endforeach()
+  endif()
 endmacro()
 
 if(BUILD_WITH_PINOCCHIO_SUPPORT AND (BUILD_EXAMPLES OR BUILD_BENCHMARKS))
   ADD_PROJECT_PRIVATE_DEPENDENCY(example-robot-data 4.0.9 REQUIRED)
-  macro(target_add_example_robot_data target_name)
-    target_link_libraries(
-      ${target_name}
-      PRIVATE example-robot-data::example-robot-data
-    )
-  endmacro()
 endif()
 
 # create an utility library to avoid recompiling crocoddyl talos arm problem
@@ -509,10 +517,13 @@ if(BUILD_CROCODDYL_COMPAT AND (BUILD_EXAMPLES OR BUILD_BENCHMARKS))
   )
   target_link_libraries(
     croc_talos_arm_utils
-    PUBLIC ${PROJECT_NAME} Boost::boost crocoddyl::crocoddyl
+    PUBLIC
+      ${PROJECT_NAME}
+      Boost::boost
+      crocoddyl::crocoddyl
+      example-robot-data::example-robot-data
   )
   set_standard_output_directory(croc_talos_arm_utils)
-  target_add_example_robot_data(croc_talos_arm_utils)
 endif()
 
 if(BUILD_BENCHMARKS OR BUILD_TESTING)
@@ -537,11 +548,10 @@ if(PINOCCHIO_V3 AND (BUILD_EXAMPLES OR BUILD_BENCHMARKS))
     PUBLIC ${PROJECT_SOURCE_DIR}/examples
   )
   set_standard_output_directory(talos_walk_utils)
-  target_link_libraries(talos_walk_utils PUBLIC ${PROJECT_NAME})
-  target_add_example_robot_data(talos_walk_utils)
-  function(target_add_talos_walk target)
-    target_link_libraries(${target} PRIVATE talos_walk_utils)
-  endfunction()
+  target_link_libraries(
+    talos_walk_utils
+    PUBLIC ${PROJECT_NAME} example-robot-data::example-robot-data
+  )
 endif()
 
 if(BUILD_EXAMPLES)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,12 +242,12 @@ if(BUILD_WITH_PINOCCHIO_SUPPORT)
       "If you didn't build proxsuite-nlp yourself, please contact the maintainer for the distribution you used."
     )
   endif()
-  add_compile_definitions(ALIGATOR_WITH_PINOCCHIO)
-  list(APPEND CFLAGS_DEPENDENCIES "-DALIGATOR_WITH_PINOCCHIO")
-  set(PINOCCHIO_V3 ${pinocchio_VERSION} VERSION_GREATER "3.0.0")
-  if(PINOCCHIO_V3)
-    add_compile_definitions(ALIGATOR_PINOCCHIO_V3)
+
+  if(${pinocchio_VERSION} VERSION_GREATER "3.0.0")
+    set(PINOCCHIO_V3 TRUE)
   endif()
+
+  list(APPEND CFLAGS_DEPENDENCIES "-DALIGATOR_WITH_PINOCCHIO")
 elseif(PROXSUITE_NLP_WITH_PINOCCHIO_SUPPORT)
   message(
     WARNING
@@ -258,7 +258,6 @@ endif()
 
 if(BUILD_CROCODDYL_COMPAT)
   message(STATUS "Building with Crocoddyl support.")
-  add_compile_definitions(ALIGATOR_WITH_CROCODDYL_COMPAT)
   list(APPEND CFLAGS_DEPENDENCIES "-DALIGATOR_WITH_CROCODDYL_COMPAT")
 endif()
 
@@ -398,6 +397,10 @@ function(create_library)
 
   if(BUILD_WITH_PINOCCHIO_SUPPORT)
     target_link_libraries(${PROJECT_NAME} PUBLIC pinocchio::pinocchio)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC ALIGATOR_WITH_PINOCCHIO)
+    if(PINOCCHIO_V3)
+      target_compile_definitions(${PROJECT_NAME} PUBLIC ALIGATOR_PINOCCHIO_V3)
+    endif()
   endif()
 
   if(BUILD_WITH_OPENMP_SUPPORT)

--- a/bench/CMakeLists.txt
+++ b/bench/CMakeLists.txt
@@ -3,39 +3,35 @@
 #
 
 # Create a benchmark
-function(create_bench exfile croc)
+function(create_bench exfile)
+  cmake_parse_arguments(arg_ex "CROC" "" "DEPENDENCIES" ${ARGN})
+  set(dependencies ${arg_ex_DEPENDENCIES})
+
   get_filename_component(_exname ${exfile} NAME_WE)
   set(_exname "bench-${_exname}")
-  create_ex_or_bench(TRUE ${exfile} ${_exname})
-
-  target_include_directories(${_exname} PRIVATE ../examples)
-  target_link_libraries(${_exname} PRIVATE benchmark::benchmark)
-  if(croc)
-    target_link_libraries(
-      ${_exname}
-      PRIVATE aligator::croc_compat croc_talos_arm_utils
-    )
+  if(${arg_ex_CROC})
+    list(APPEND dependencies aligator::croc_compat croc_talos_arm_utils)
   endif()
+  create_ex_or_bench(
+    ${exfile}
+    ${_exname}
+    BENCHMARK
+    DEPENDENCIES ${dependencies}
+  )
+  target_include_directories(${_exname} PRIVATE ../examples)
 endfunction()
 
 function(create_gar_bench exfile)
-  get_filename_component(_exname ${exfile} NAME_WE)
-  set(_exname "bench-${_exname}")
-  create_ex_or_bench(TRUE ${exfile} ${_exname})
-
-  target_link_libraries(${_exname} PRIVATE benchmark::benchmark gar_test_utils)
+  create_bench(${exfile} DEPENDENCIES gar_test_utils)
 endfunction()
 
-create_bench(lqr.cpp FALSE)
-create_bench(se2-car.cpp FALSE)
+create_bench(lqr.cpp)
+create_bench(se2-car.cpp)
 if(BUILD_CROCODDYL_COMPAT)
-  create_bench(croc-talos-arm.cpp TRUE)
-  target_add_example_robot_data(bench-croc-talos-arm)
+  create_bench(croc-talos-arm.cpp CROC)
 endif()
 if(PINOCCHIO_V3)
-  create_bench(talos-walk.cpp FALSE)
-  target_add_example_robot_data(bench-talos-walk)
-  target_add_talos_walk(bench-talos-walk)
+  create_bench(talos-walk.cpp CROC DEPENDENCIES talos_walk_utils)
 endif()
 
 create_gar_bench(gar-riccati.cpp)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -20,40 +20,24 @@ function(create_example exfile)
 
   get_filename_component(exname ${exfile} NAME_WE)
   set(exname "${PROJECT_NAME}-example-${exname}")
-  create_ex_or_bench(False ${exfile} ${exname})
-  if(DEFINED arg_crex_DEPENDENCIES)
-    message("   > depends on ${arg_crex_DEPENDENCIES}")
-    foreach(dep ${arg_crex_DEPENDENCIES})
-      target_link_libraries(${exname} PRIVATE ${dep})
-    endforeach()
-  endif()
+  create_ex_or_bench(${exfile} ${exname} DEPENDENCIES ${arg_crex_DEPENDENCIES})
 endfunction()
 
-set(EXAMPLES_LIST clqr)
+create_example(clqr.cpp)
 
 if(PROXSUITE_NLP_WITH_PINOCCHIO_SUPPORT)
-  list(APPEND EXAMPLES_LIST se2-car)
-endif()
-if(PINOCCHIO_V3)
-  list(APPEND EXAMPLES_LIST talos-walk)
+  create_example(se2-car.cpp)
 endif()
 
-foreach(filename ${EXAMPLES_LIST})
-  create_example(${filename}.cpp)
-endforeach()
-
 if(PINOCCHIO_V3)
-  target_add_talos_walk(aligator-example-talos-walk)
+  create_example(talos-walk.cpp DEPENDENCIES talos_walk_utils)
 endif()
 
 if(BUILD_CROCODDYL_COMPAT)
   ADD_PROJECT_PRIVATE_DEPENDENCY(example-robot-data 4.0.9 REQUIRED)
   create_example(
     talos-arm.cpp
-    DEPENDENCIES
-      aligator::croc_compat
-      croc_talos_arm_utils
-      example-robot-data::example-robot-data
+    DEPENDENCIES aligator::croc_compat croc_talos_arm_utils
   )
 endif()
 

--- a/src/compat/crocoddyl/CMakeLists.txt
+++ b/src/compat/crocoddyl/CMakeLists.txt
@@ -31,6 +31,10 @@ target_link_libraries(
   aligator_croc_compat
   PUBLIC ${PROJECT_NAME} crocoddyl::crocoddyl
 )
+target_compile_definitions(
+  aligator_croc_compat
+  PUBLIC ALIGATOR_WITH_CROCODDYL_COMPAT
+)
 
 install(
   TARGETS aligator_croc_compat

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,7 +18,7 @@ message(STATUS "Test headers: ${TEST_HEADERS}")
 function(_add_test_prototype name prefix dependencies)
   set(test_name "${PROJECT_NAME}-test-cpp-${prefix}${name}")
   set(test_file ${name}.cpp)
-  message(STATUS "Adding cpp test: ${test_file} (${test_name})")
+  message(STATUS "Adding cpp test: ${test_name} (${test_file})")
 
   ADD_UNIT_TEST(${test_name} ${test_file} ${TEST_HEADERS})
   set_target_properties(${test_name} PROPERTIES LINKER_LANGUAGE CXX)


### PR DESCRIPTION
[cmake] add a comment

[cmake] scoped target compile definitions

[cmake] tests: slight tweak to message printing target name and cpp file

gersemi: add bench/ dir

[cmake] Use cmake_parse_arguments() some more

create_ex_or_bench:
- add keyword arg BENCHMARK
- add multivalue arg DEPENDENCIES
- message: print filename between parentheses

Remove CMake macros:
- target_add_example_robot_data
- target_add_talos_walk
(directly add targets example-robot-data and talos_walk_utils

examples/CMakeLists.txt : do not use list EXAMPLES_LIST anymore
- create_example() : move message print to create_ex_or_bench call
- do not link talos-arm.cpp to example_robot_data explicitly -- croc_talos_arm_utils already had it