### PR TITLE
Don't link against all pinocchio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `LinesearchVariant::init()` should not be called unless the step accpetance strategy is a linesearch
 - Fixed compilation issues with C++20 (resolving [#246](https://github.com/Simple-Robotics/aligator/issues/246) and [#254](https://github.com/Simple-Robotics/aligator/discussions/254))
 
+### Changed
+
+- Only link against needed pinocchio libraries ([#260](https://github.com/Simple-Robotics/aligator/pull/260))
+
 ## [0.10.0] - 2024-12-09
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -398,7 +398,7 @@ function(create_library)
   )
 
   if(BUILD_WITH_PINOCCHIO_SUPPORT)
-    target_link_libraries(${PROJECT_NAME} PUBLIC pinocchio::pinocchio)
+    target_link_libraries(${PROJECT_NAME} PUBLIC pinocchio::pinocchio_default)
   endif()
 
   if(BUILD_WITH_OPENMP_SUPPORT)
@@ -538,7 +538,7 @@ if(PINOCCHIO_V3 AND (BUILD_EXAMPLES OR BUILD_BENCHMARKS))
   target_link_libraries(talos_walk_utils PUBLIC ${PROJECT_NAME})
   target_add_example_robot_data(talos_walk_utils)
   function(target_add_talos_walk target)
-    target_link_libraries(${target} PRIVATE talos_walk_utils)
+    target_link_libraries(${target} PRIVATE talos_walk_utils pinocchio::pinocchio_parsers)
   endfunction()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -538,7 +538,10 @@ if(PINOCCHIO_V3 AND (BUILD_EXAMPLES OR BUILD_BENCHMARKS))
   target_link_libraries(talos_walk_utils PUBLIC ${PROJECT_NAME})
   target_add_example_robot_data(talos_walk_utils)
   function(target_add_talos_walk target)
-    target_link_libraries(${target} PRIVATE talos_walk_utils pinocchio::pinocchio_parsers)
+    target_link_libraries(
+      ${target}
+      PRIVATE talos_walk_utils pinocchio::pinocchio_parsers
+    )
   endfunction()
 endif()
 


### PR DESCRIPTION
The CMake pinocchio::pinocchio target link against all pinocchio sublibrary.

Aligator only need pinocchio_default (standard algorithms build with double) and pinocchio_parsers in one example.

Drawback : this fix doesn't support Pinocchio 2.
