### PR TITLE
Fix copy of TrajOptProblem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed copy of TrajOptProblem ([#265](https://github.com/Simple-Robotics/aligator/pull/265))
 - `LinesearchVariant::init()` should not be called unless the step accpetance strategy is a linesearch
 - Fixed compilation issues with C++20 (resolving [#246](https://github.com/Simple-Robotics/aligator/issues/246) and [#254](https://github.com/Simple-Robotics/aligator/discussions/254))
 

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Please also consider citing the reference paper for the ProxDDP algorithm:
 * [Fabian Schramm](https://github.com/fabinsch) (Inria): core developer
 * [Ludovic De Matteïs](https://github.com/LudovicDeMatteis) (LAAS-CNRS/Inria): feature developer
 * [Ewen Dantec](https://edantec.github.io/) (Inria): feature developer
+* [Antoine Bussy](https://github.com/antoine-bussy) (Aldebaran)
 
 ## Acknowledgments
 

--- a/tests/problem.cpp
+++ b/tests/problem.cpp
@@ -151,4 +151,24 @@ BOOST_AUTO_TEST_CASE(test_workspace) {
   ResultsTpl<double> results(f.problem);
 }
 
+BOOST_AUTO_TEST_CASE(test_copy) {
+  MyFixture f;
+
+  auto copy = f.problem;
+  BOOST_CHECK_EQUAL(copy.getInitState(), f.problem.getInitState());
+
+  Eigen::VectorXd state = f.problem.getInitState();
+
+  state[0] = 0.;
+  f.problem.setInitState(state);
+  BOOST_CHECK_EQUAL(f.problem.getInitState()[0], 0.);
+
+  state[0] = 1.;
+  BOOST_CHECK_EQUAL(f.problem.getInitState()[0], 0.);
+
+  copy.setInitState(state);
+  BOOST_CHECK_EQUAL(copy.getInitState()[0], 1.);
+  BOOST_CHECK_EQUAL(f.problem.getInitState()[0], 0.);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Hi,

When I tried to run the solo12 scenario from https://gitlab.laas.fr/gepetto/quadruped-reactive-walking, I got crashes from aligator.
I identified the following bug : the pointer `init_state_error_` in `TrajOptProblemTpl` was not updated across copy/move, which could result in wrong values or crashes.
I tried to make `TrajOptProblemTpl` non copyable nor movable, but I couldn't find a fix that would not break the python binding.

So I went for the obvious fix. Please let me know if you prefer another solution.