### PR TITLE
Prevent duplication of log columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed copy of TrajOptProblem ([#265](https://github.com/Simple-Robotics/aligator/pull/265))
 - `LinesearchVariant::init()` should not be called unless the step accpetance strategy is a linesearch
 - Fixed compilation issues with C++20 (resolving [#246](https://github.com/Simple-Robotics/aligator/issues/246) and [#254](https://github.com/Simple-Robotics/aligator/discussions/254))
+- Prevent duplication of log columns ([#271](https://github.com/Simple-Robotics/aligator/pull/271))
 
 ### Added
 

--- a/src/utils/logger.cpp
+++ b/src/utils/logger.cpp
@@ -49,7 +49,8 @@ void Logger::finish(bool conv) {
 
 void Logger::addColumn(std::string_view name, uint width,
                        std::string_view format) {
-  m_colNames.push_back(name);
+  if (std::find(m_colNames.begin(), m_colNames.end(), name) == m_colNames.end())
+    m_colNames.push_back(name);
   m_colSpecs[name] = {width, std::string(format)};
 }
 


### PR DESCRIPTION
Prevent duplication of log columns.
Duplication becomes problematic with multiple runs, e.g. in MPC.
