### PR TITLE
Allow customization of the initial solution.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add MPC test/example ([#272](https://github.com/Simple-Robotics/aligator/pull/272))
+- Allow customization of the initial solution ([#274](https://github.com/Simple-Robotics/aligator/pull/274))
 - Add a collision distance residual for collision pair
 - Add a relaxed log-barrier cost function
 - Add Nix support ([#268](https://github.com/Simple-Robotics/aligator/pull/268))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Only link against needed pinocchio libraries ([#260](https://github.com/Simple-Robotics/aligator/pull/260))
 - Use Pinocchio instantiated functions ([#261](https://github.com/Simple-Robotics/aligator/pull/261))
 - Link to pinocchio collision
+- Some internal code now uses `TrajOptProblemTpl::initializeSolution()` to initialize state-control trajectories ([#274](https://github.com/Simple-Robotics/aligator/pull/274))
 
 ### Fixed
 
@@ -23,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add MPC test/example ([#272](https://github.com/Simple-Robotics/aligator/pull/272))
-- Allow customization of the initial solution ([#274](https://github.com/Simple-Robotics/aligator/pull/274))
+- Allow customization of the initial solution, introduce initialization strategies ([#274](https://github.com/Simple-Robotics/aligator/pull/274))
 - Add a collision distance residual for collision pair
 - Add a relaxed log-barrier cost function
 - Add Nix support ([#268](https://github.com/Simple-Robotics/aligator/pull/268))

--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -25,7 +25,7 @@ PREDEFINED              += EIGEN_MAKE_ALIGNED_OPERATOR_NEW \
                            ALIGATOR_RAISE_IF_NAN
 
 FULL_PATH_NAMES         = YES
-EXCLUDE_SYMBOLS         = *::internal, internal::*, *::internal::*
+EXCLUDE_SYMBOLS         = *::internal, internal::*, *::internal::*, boost::*, fmt::*
 # Do not show source files
 EXCLUDE_PATTERNS        = *.hxx
 
@@ -62,7 +62,7 @@ SOURCE_BROWSER          = YES
 
 ALPHABETICAL_INDEX      = YES
 
-USE_MDFILE_AS_MAINPAGE  = README.md
+USE_MDFILE_AS_MAINPAGE  = @PROJECT_SOURCE_DIR@/README.md
 
 BUILTIN_STL_SUPPORT     = YES
 HAVE_DOT                = YES

--- a/include/aligator/core/solver-util.hpp
+++ b/include/aligator/core/solver-util.hpp
@@ -85,7 +85,7 @@ void check_trajectory_and_assign(
     typename math_types<Scalar>::VectorOfVectors &xs_out,
     typename math_types<Scalar>::VectorOfVectors &us_out) {
   if (xs_in.empty()) {
-    problem.executeInitialization(xs_out, us_out);
+    problem.initializeSolution(xs_out, us_out);
   } else if (us_in.empty()) {
     us_default_init(problem, us_out);
   } else {

--- a/include/aligator/core/solver-util.hpp
+++ b/include/aligator/core/solver-util.hpp
@@ -68,6 +68,7 @@ template <typename T1, typename T2>
   return true;
 }
 
+namespace detail {
 /// @brief Check the input state-control trajectory is a consistent warm-start
 /// for the output.
 ///
@@ -78,7 +79,7 @@ template <typename T1, typename T2>
 /// are empty, we attempt to assign the given @p xs_in and
 /// @p us_in values.
 template <typename Scalar>
-void check_trajectory_and_assign(
+void check_initial_guess_and_assign(
     const TrajOptProblemTpl<Scalar> &problem,
     const typename math_types<Scalar>::VectorOfVectors &xs_in,
     const typename math_types<Scalar>::VectorOfVectors &us_in,
@@ -95,5 +96,6 @@ void check_trajectory_and_assign(
       ALIGATOR_RUNTIME_ERROR("warm-start for us has wrong size!");
   }
 }
+} // namespace detail
 
 } // namespace aligator

--- a/include/aligator/core/traj-opt-problem.hpp
+++ b/include/aligator/core/traj-opt-problem.hpp
@@ -199,7 +199,7 @@ template <typename _Scalar> struct TrajOptProblemTpl {
   /// @warning Call this set before the solver's setup().
   /// @tparam Callable Functional type convertible to InitializationStrategy.
   ///
-  /// @sa executeInitialization()
+  /// @sa initializeSolution()
   template <typename Callable> void setInitializationStrategy(Callable &&func) {
     static_assert(std::is_convertible_v<Callable, InitializationStrategy>);
     this->xs_init_strategy_ = std::forward<Callable>(func);
@@ -209,19 +209,18 @@ template <typename _Scalar> struct TrajOptProblemTpl {
   /// candidate solution to the problem.
   ///
   /// @sa setInitializationStrategy()
-  void executeInitialization(std::vector<VectorXs> &xs,
-                             std::vector<VectorXs> &us) const {
+  void initializeSolution(std::vector<VectorXs> &xs,
+                          std::vector<VectorXs> &us) const {
     xs_init_strategy_(*this, xs);
     us_default_init(*this, us);
   }
 
-  /// @copydoc executeInitialization()
-  void executeInitialization(std::vector<VectorXs> &xs,
-                             std::vector<VectorXs> &us,
-                             std::vector<VectorXs> &vs,
-                             std::vector<VectorXs> &lbdas) const {
+  /// @copydoc initializeSolution()
+  void initializeSolution(std::vector<VectorXs> &xs, std::vector<VectorXs> &us,
+                          std::vector<VectorXs> &vs,
+                          std::vector<VectorXs> &lbdas) const {
     const size_t nsteps = numSteps();
-    executeInitialization(xs, us);
+    initializeSolution(xs, us);
     // initialize multipliers...
     vs.resize(nsteps + 1);
     lbdas.resize(nsteps + 1);
@@ -237,10 +236,10 @@ template <typename _Scalar> struct TrajOptProblemTpl {
     }
   }
 
-  /// @copydoc executeInitialization()
+  /// @copydoc initializeSolution()
   [[nodiscard]] auto initializeSolution() const {
     std::vector<VectorXs> xs, us, vs, lbdas;
-    executeInitialization(xs, us, vs, lbdas);
+    initializeSolution(xs, us, vs, lbdas);
     return std::make_tuple(std::move(xs), std::move(us), std::move(vs),
                            std::move(lbdas));
   }

--- a/include/aligator/core/traj-opt-problem.hxx
+++ b/include/aligator/core/traj-opt-problem.hxx
@@ -19,7 +19,7 @@ TrajOptProblemTpl<Scalar>::TrajOptProblemTpl(
     xyz::polymorphic<CostAbstract> term_cost)
     : init_constraint_(std::move(init_constraint)), stages_(stages),
       term_cost_(std::move(term_cost)), unone_(term_cost_->nu),
-      xs_traj_initializer_(xs_default_init<Scalar>),
+      xs_init_strategy_(xs_default_init<Scalar>),
       init_cond_is_state_error_(checkInitCondIsStateError()) {
   unone_.setZero();
 }

--- a/include/aligator/core/traj-opt-problem.hxx
+++ b/include/aligator/core/traj-opt-problem.hxx
@@ -1,9 +1,10 @@
 /// @file
-/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, 2022-2025 INRIA
 /// @brief Template definitions header.
 #pragma once
 
 #include "aligator/core/traj-opt-problem.hpp"
+#include "aligator/core/solver-util.hpp"
 #include "aligator/utils/mpc-util.hpp"
 #include "aligator/tracy.hpp"
 
@@ -18,6 +19,7 @@ TrajOptProblemTpl<Scalar>::TrajOptProblemTpl(
     xyz::polymorphic<CostAbstract> term_cost)
     : init_constraint_(std::move(init_constraint)), stages_(stages),
       term_cost_(std::move(term_cost)), unone_(term_cost_->nu),
+      xs_traj_initializer_(xs_default_init<Scalar>),
       init_cond_is_state_error_(checkInitCondIsStateError()) {
   unone_.setZero();
 }

--- a/include/aligator/core/workspace-base.hpp
+++ b/include/aligator/core/workspace-base.hpp
@@ -62,7 +62,7 @@ WorkspaceBaseTpl<Scalar>::WorkspaceBaseTpl(
     : m_isInitialized(true), nsteps(problem.numSteps()), problem_data(problem) {
   trial_xs.resize(nsteps + 1);
   trial_us.resize(nsteps);
-  xs_default_init(problem, trial_xs);
+  problem.xs_traj_initializer_(problem, trial_xs);
   us_default_init(problem, trial_us);
 }
 

--- a/include/aligator/core/workspace-base.hpp
+++ b/include/aligator/core/workspace-base.hpp
@@ -60,10 +60,7 @@ template <typename Scalar>
 WorkspaceBaseTpl<Scalar>::WorkspaceBaseTpl(
     const TrajOptProblemTpl<Scalar> &problem)
     : m_isInitialized(true), nsteps(problem.numSteps()), problem_data(problem) {
-  trial_xs.resize(nsteps + 1);
-  trial_us.resize(nsteps);
-  problem.xs_traj_initializer_(problem, trial_xs);
-  us_default_init(problem, trial_us);
+  problem.executeInitialization(trial_xs, trial_us);
 }
 
 template <typename Scalar> void WorkspaceBaseTpl<Scalar>::cycleLeft() {

--- a/include/aligator/core/workspace-base.hpp
+++ b/include/aligator/core/workspace-base.hpp
@@ -60,7 +60,7 @@ template <typename Scalar>
 WorkspaceBaseTpl<Scalar>::WorkspaceBaseTpl(
     const TrajOptProblemTpl<Scalar> &problem)
     : m_isInitialized(true), nsteps(problem.numSteps()), problem_data(problem) {
-  problem.executeInitialization(trial_xs, trial_us);
+  problem.initializeSolution(trial_xs, trial_us);
 }
 
 template <typename Scalar> void WorkspaceBaseTpl<Scalar>::cycleLeft() {

--- a/include/aligator/solvers/fddp/results.hpp
+++ b/include/aligator/solvers/fddp/results.hpp
@@ -29,8 +29,7 @@ ResultsFDDPTpl<Scalar>::ResultsFDDPTpl(
   xs.resize(nsteps + 1);
   us.resize(nsteps);
 
-  problem.xs_traj_initializer_(problem, xs);
-  us_default_init(problem, us);
+  problem.executeInitialization(xs, us);
 
   gains_.resize(nsteps);
 

--- a/include/aligator/solvers/fddp/results.hpp
+++ b/include/aligator/solvers/fddp/results.hpp
@@ -29,7 +29,7 @@ ResultsFDDPTpl<Scalar>::ResultsFDDPTpl(
   xs.resize(nsteps + 1);
   us.resize(nsteps);
 
-  problem.executeInitialization(xs, us);
+  problem.initializeSolution(xs, us);
 
   gains_.resize(nsteps);
 

--- a/include/aligator/solvers/fddp/results.hpp
+++ b/include/aligator/solvers/fddp/results.hpp
@@ -29,7 +29,7 @@ ResultsFDDPTpl<Scalar>::ResultsFDDPTpl(
   xs.resize(nsteps + 1);
   us.resize(nsteps);
 
-  xs_default_init(problem, xs);
+  problem.xs_traj_initializer_(problem, xs);
   us_default_init(problem, us);
 
   gains_.resize(nsteps);

--- a/include/aligator/solvers/fddp/solver-fddp.hxx
+++ b/include/aligator/solvers/fddp/solver-fddp.hxx
@@ -285,8 +285,8 @@ bool SolverFDDPTpl<Scalar>::run(const Problem &problem,
         "Either results or workspace not allocated. Call setup() first!");
   }
 
-  check_trajectory_and_assign(problem, xs_init, us_init, results_.xs,
-                              results_.us);
+  detail::check_initial_guess_and_assign(problem, xs_init, us_init, results_.xs,
+                                         results_.us);
   // optionally override xs[0]
   if (force_initial_condition_) {
     workspace_.trial_xs[0] = problem.getInitState();

--- a/include/aligator/solvers/proxddp/results.hxx
+++ b/include/aligator/solvers/proxddp/results.hxx
@@ -1,5 +1,6 @@
 /// @file
-/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2022-2024 LAAS-CNRS
+///            Copyright (C) 2022-2025 INRIA
 /// @brief Implementation file. Include when template definitions required.
 #pragma once
 
@@ -16,10 +17,7 @@ ResultsTpl<Scalar>::ResultsTpl(const TrajOptProblemTpl<Scalar> &problem)
     ALIGATOR_RUNTIME_ERROR("Problem failed integrity check.");
 
   const std::size_t nsteps = problem.numSteps();
-  std::tie(xs, us, vs, lams) = problemInitializeSolution(problem);
-
-  assert(xs.size() == nsteps + 1);
-  assert(us.size() == nsteps);
+  std::tie(xs, us, vs, lams) = problem.initializeSolution();
 
   gains_.resize(nsteps + 1);
   for (std::size_t i = 0; i < nsteps; i++) {

--- a/include/aligator/solvers/proxddp/results.hxx
+++ b/include/aligator/solvers/proxddp/results.hxx
@@ -16,7 +16,7 @@ ResultsTpl<Scalar>::ResultsTpl(const TrajOptProblemTpl<Scalar> &problem)
     ALIGATOR_RUNTIME_ERROR("Problem failed integrity check.");
 
   const std::size_t nsteps = problem.numSteps();
-  problem.executeInitialization(xs, us, vs, lams);
+  problem.initializeSolution(xs, us, vs, lams);
 
   gains_.resize(nsteps + 1);
   for (std::size_t i = 0; i < nsteps; i++) {

--- a/include/aligator/solvers/proxddp/results.hxx
+++ b/include/aligator/solvers/proxddp/results.hxx
@@ -1,6 +1,5 @@
 /// @file
-/// @copyright Copyright (C) 2022-2024 LAAS-CNRS
-///            Copyright (C) 2022-2025 INRIA
+/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, 2022-2025 INRIA
 /// @brief Implementation file. Include when template definitions required.
 #pragma once
 
@@ -17,7 +16,7 @@ ResultsTpl<Scalar>::ResultsTpl(const TrajOptProblemTpl<Scalar> &problem)
     ALIGATOR_RUNTIME_ERROR("Problem failed integrity check.");
 
   const std::size_t nsteps = problem.numSteps();
-  std::tie(xs, us, vs, lams) = problem.initializeSolution();
+  problem.executeInitialization(xs, us, vs, lams);
 
   gains_.resize(nsteps + 1);
   for (std::size_t i = 0; i < nsteps; i++) {

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -470,8 +470,8 @@ bool SolverProxDDPTpl<Scalar>::run(const Problem &problem,
     setAlmPenalty(mu_init);
   }
 
-  check_trajectory_and_assign(problem, xs_init, us_init, results_.xs,
-                              results_.us);
+  detail::check_initial_guess_and_assign(problem, xs_init, us_init, results_.xs,
+                                         results_.us);
   const bool v_was_resized =
       !vs_init.empty() && !assign_no_resize(vs_init, results_.vs);
   const bool l_was_resized =

--- a/include/aligator/solvers/proxddp/workspace.hxx
+++ b/include/aligator/solvers/proxddp/workspace.hxx
@@ -1,5 +1,5 @@
 /// @file
-/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, 2022-2025 INRIA
 /// @brief Implementation file, to be included when necessary.
 #pragma once
 
@@ -19,7 +19,7 @@ WorkspaceTpl<Scalar>::WorkspaceTpl(const TrajOptProblemTpl<Scalar> &problem)
     ALIGATOR_RUNTIME_ERROR("Problem failed integrity check.");
 
   std::tie(trial_xs, trial_us, trial_vs, trial_lams) =
-      problemInitializeSolution(problem);
+      problem.initializeSolution();
   std::tie(prev_xs, prev_us, prev_vs, prev_lams) = {trial_xs, trial_us,
                                                     trial_vs, trial_lams};
 

--- a/include/aligator/solvers/proxddp/workspace.hxx
+++ b/include/aligator/solvers/proxddp/workspace.hxx
@@ -18,8 +18,7 @@ WorkspaceTpl<Scalar>::WorkspaceTpl(const TrajOptProblemTpl<Scalar> &problem)
   if (!problem.checkIntegrity())
     ALIGATOR_RUNTIME_ERROR("Problem failed integrity check.");
 
-  std::tie(trial_xs, trial_us, trial_vs, trial_lams) =
-      problem.initializeSolution();
+  problem.executeInitialization(trial_xs, trial_us, trial_vs, trial_lams);
   std::tie(prev_xs, prev_us, prev_vs, prev_lams) = {trial_xs, trial_us,
                                                     trial_vs, trial_lams};
 

--- a/include/aligator/solvers/proxddp/workspace.hxx
+++ b/include/aligator/solvers/proxddp/workspace.hxx
@@ -18,7 +18,7 @@ WorkspaceTpl<Scalar>::WorkspaceTpl(const TrajOptProblemTpl<Scalar> &problem)
   if (!problem.checkIntegrity())
     ALIGATOR_RUNTIME_ERROR("Problem failed integrity check.");
 
-  problem.executeInitialization(trial_xs, trial_us, trial_vs, trial_lams);
+  problem.initializeSolution(trial_xs, trial_us, trial_vs, trial_lams);
   std::tie(prev_xs, prev_us, prev_vs, prev_lams) = {trial_xs, trial_us,
                                                     trial_vs, trial_lams};
 

--- a/tests/problem.cpp
+++ b/tests/problem.cpp
@@ -211,9 +211,9 @@ BOOST_AUTO_TEST_CASE(test_constant_init) {
   state[0] += 1.;
   f.problem.setInitState(state);
 
-  f.problem.xs_traj_initializer_ = [](const auto &problem, auto &xs) {
+  f.problem.setInitializationStrategy([](const auto &problem, auto &xs) {
     xs.assign(problem.numSteps() + 1, problem.getInitState());
-  };
+  });
 
   auto ddp = SolverProxDDPTpl<double>();
   ddp.setup(f.problem);


### PR DESCRIPTION
By default, if TrajOptProblem is given an initial state, the initial solution is initialized with this initial state for the first element, and with the neutral state for the others. Both these states can have very different values, yielding poor starting values for xs, prev_xs and trial_xs. In the classical case where all the states are in the same stage space, one might want to start with a constant solution. Instead of trying to detect if this is a desirable behavior, or adding a configuration parameter, an initialization callback is added to the problem, which can be set by the user before calling the solver setup(). If it is not set, the previous default behavior applies.