### PR TITLE
[gar] Rename {LQRKnot,LQRProblem} to {LqrKnot, LqrProblem}

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Rename `LQRKnotTpl` (C++)/`LqrKnot` (Python) to `LqrKnot(Tpl)`
+- Rename `LQRProblemTpl` (C++)/`LQRProblem` (Python) to `LqrProblem(Tpl)`
+
 ## [0.12.0] - 2025-03-27
 
 ### Changed

--- a/bench/gar-riccati.cpp
+++ b/bench/gar-riccati.cpp
@@ -21,7 +21,7 @@ const uint nu = 12;
 static void BM_serial(benchmark::State &state) {
   uint horz = (uint)state.range(0);
   VectorXs x0 = VectorXs::NullaryExpr(nx, normal_unary_op{});
-  const LQRProblemTpl<double> problem = generate_problem(x0, horz, nx, nu);
+  const LqrProblemTpl<double> problem = generate_problem(x0, horz, nx, nu);
   ProximalRiccatiSolver<double> solver(problem);
   const double mu = 1e-11;
   auto [xs, us, vs, lbdas] = lqrInitializeSolution(problem);
@@ -35,7 +35,7 @@ static void BM_serial(benchmark::State &state) {
 template <uint NPROC> static void BM_parallel(benchmark::State &state) {
   uint horz = (uint)state.range(0);
   VectorXs x0 = VectorXs::NullaryExpr(nx, normal_unary_op{});
-  LQRProblemTpl<double> problem = generate_problem(x0, horz, nx, nu);
+  LqrProblemTpl<double> problem = generate_problem(x0, horz, nx, nu);
   ParallelRiccatiSolver<double> solver(problem, NPROC);
   const double mu = 1e-11;
   auto [xs, us, vs, lbdas] = lqrInitializeSolution(problem);
@@ -49,7 +49,7 @@ template <uint NPROC> static void BM_parallel(benchmark::State &state) {
 static void BM_stagedense(benchmark::State &state) {
   uint horz = (uint)state.range(0);
   VectorXs x0 = VectorXs::NullaryExpr(nx, normal_unary_op{});
-  LQRProblemTpl<double> problem = generate_problem(x0, horz, nx, nu);
+  LqrProblemTpl<double> problem = generate_problem(x0, horz, nx, nu);
   RiccatiSolverDense<double> solver(problem);
   const double mu = 1e-11;
   auto [xs, us, vs, lbdas] = lqrInitializeSolution(problem);

--- a/bindings/python/src/gar/expose-cholmod-solver.cpp
+++ b/bindings/python/src/gar/expose-cholmod-solver.cpp
@@ -4,7 +4,7 @@
 
 namespace aligator::python {
 
-using lqr_t = gar::LQRProblemTpl<context::Scalar>;
+using lqr_t = gar::LqrProblemTpl<context::Scalar>;
 using cholmod_solver_t = gar::CholmodLqSolver<context::Scalar>;
 
 void exposeCholmodSolver() {

--- a/bindings/python/src/gar/expose-dense.cpp
+++ b/bindings/python/src/gar/expose-dense.cpp
@@ -8,7 +8,7 @@ namespace aligator::python {
 using namespace gar;
 using context::Scalar;
 using riccati_base_t = RiccatiSolverBase<Scalar>;
-using lqr_t = LQRProblemTpl<context::Scalar>;
+using lqr_t = LqrProblemTpl<context::Scalar>;
 
 void exposeDenseSolver() {
 

--- a/bindings/python/src/gar/expose-gar.cpp
+++ b/bindings/python/src/gar/expose-gar.cpp
@@ -14,8 +14,8 @@ using namespace gar;
 
 using context::Scalar;
 using riccati_base_t = RiccatiSolverBase<Scalar>;
-using knot_t = LQRKnotTpl<context::Scalar>;
-using lqr_t = LQRProblemTpl<context::Scalar>;
+using knot_t = LqrKnotTpl<context::Scalar>;
+using lqr_t = LqrProblemTpl<context::Scalar>;
 
 using context::MatrixXs;
 using RowMatrixXs = Eigen::Transpose<MatrixXs>::PlainMatrix;
@@ -58,7 +58,7 @@ void exposeGAR() {
 
   exposeBlockMatrices();
 
-  bp::class_<knot_t>("LQRKnot", bp::no_init)
+  bp::class_<knot_t>("LqrKnot", bp::no_init)
       .def(bp::init<uint, uint, uint>(("nx"_a, "nu", "nc")))
       .def(bp::init<uint, uint, uint, uint>(("nx"_a, "nu", "nc", "nx2")))
       .def_readonly("nx", &knot_t::nx)
@@ -93,9 +93,9 @@ void exposeGAR() {
       .def(CopyableVisitor<knot_t>())
       .def(PrintableVisitor<knot_t>());
 
-  StdVectorPythonVisitor<knot_vec_t, false>::expose("StdVec_LQRKnot");
+  StdVectorPythonVisitor<knot_vec_t, false>::expose("StdVec_LqrKnot");
 
-  bp::class_<lqr_t>("LQRProblem", bp::no_init)
+  bp::class_<lqr_t>("LqrProblem", bp::no_init)
       .def(bp::init<const knot_vec_t &, long>(("self"_a, "stages", "nc0")))
       .def_readwrite("stages", &lqr_t::stages)
       .add_property("horizon", &lqr_t::horizon)

--- a/bindings/python/src/gar/expose-parallel.cpp
+++ b/bindings/python/src/gar/expose-parallel.cpp
@@ -10,8 +10,8 @@ namespace python {
 using namespace gar;
 using context::Scalar;
 using riccati_base_t = RiccatiSolverBase<Scalar>;
-using knot_t = LQRKnotTpl<context::Scalar>;
-using lqr_t = LQRProblemTpl<context::Scalar>;
+using knot_t = LqrKnotTpl<context::Scalar>;
+using lqr_t = LqrProblemTpl<context::Scalar>;
 
 void exposeParallelSolver() {
 #ifdef ALIGATOR_MULTITHREADING

--- a/bindings/python/src/gar/expose-prox-riccati.cpp
+++ b/bindings/python/src/gar/expose-prox-riccati.cpp
@@ -8,7 +8,7 @@ using context::Scalar;
 using prox_riccati_t = ProximalRiccatiSolver<Scalar>;
 using stage_factor_t = StageFactor<Scalar>;
 using riccati_base_t = RiccatiSolverBase<Scalar>;
-using lqr_t = LQRProblemTpl<context::Scalar>;
+using lqr_t = LqrProblemTpl<context::Scalar>;
 
 void exposeProxRiccati() {
 

--- a/bindings/python/src/gar/expose-utils.cpp
+++ b/bindings/python/src/gar/expose-utils.cpp
@@ -8,7 +8,7 @@ using namespace gar;
 
 using context::Scalar;
 using context::VectorXs;
-using lqr_t = LQRProblemTpl<context::Scalar>;
+using lqr_t = LqrProblemTpl<context::Scalar>;
 
 bp::dict lqr_sol_initialize_wrap(const lqr_t &problem) {
   bp::dict out;
@@ -42,7 +42,7 @@ void exposeGarUtils() {
 
   bp::def("lqrCreateSparseMatrix", lqr_create_sparse_wrap,
           ("problem"_a, "mudyn", "mueq", "update"),
-          "Create or update a sparse matrix from an LQRProblem.");
+          "Create or update a sparse matrix from an LqrProblem.");
 
   bp::def("lqrInitializeSolution", lqr_sol_initialize_wrap, ("problem"_a));
 

--- a/examples/gar-cycle-lqr-1d.py
+++ b/examples/gar-cycle-lqr-1d.py
@@ -14,7 +14,7 @@ nu = 1
 
 
 def create_knot(nx, nu):
-    knot = gar.LQRKnot(nx, nu, 0)
+    knot = gar.LqrKnot(nx, nu, 0)
     knot.Q[:] = np.eye(nx) * 0.01
     knot.R[:] = np.eye(nu) * 0.01
     knot.r[:] = (2 * np.random.rand(nx) - 1) * 0.01
@@ -29,7 +29,7 @@ T = 30
 base_knot = create_knot(nx, nu)
 knots = [base_knot for _ in range(T)]
 knots.append(create_knot(nx, 0))
-prob = gar.LQRProblem(knots, 0)
+prob = gar.LqrProblem(knots, 0)
 
 PARAM_DIM = nx
 prob.addParameterization(PARAM_DIM)

--- a/examples/gar-cycle-lqr-2d.py
+++ b/examples/gar-cycle-lqr-2d.py
@@ -18,7 +18,7 @@ def random_unit(size):
 
 
 def create_knot(nx, nu):
-    knot = gar.LQRKnot(nx, nu, 0)
+    knot = gar.LqrKnot(nx, nu, 0)
     knot.Q[:] = np.eye(nx) * 1e-3
     knot.R[:] = np.eye(nu) * 0.1
     th = 0.156
@@ -35,7 +35,7 @@ T = 20
 base_knot = create_knot(nx, nu)
 knots = [base_knot for _ in range(T)]
 knots.append(create_knot(nx, 0))
-prob = gar.LQRProblem(knots, 0)
+prob = gar.LqrProblem(knots, 0)
 
 PARAM_DIM = nx
 prob.addParameterization(PARAM_DIM)

--- a/examples/gar-elqr.py
+++ b/examples/gar-elqr.py
@@ -28,7 +28,7 @@ xterm = np.array([0.0])
 
 
 def knot_get_default(nx, nu, nc):
-    knot = gar.LQRKnot(nx, nu, nc)
+    knot = gar.LqrKnot(nx, nu, nc)
     knot.Q[:] = np.eye(nx, nx) * 0.1
     knot.q[:] = 0.0
     knot.R[:] = np.eye(nu) * 0.1
@@ -76,7 +76,7 @@ for t in range(T - 1):
     knots.append(knot_mid)
 knots.append(knot1)
 # constructor creates a copy
-prob = gar.LQRProblem(knots, nx)
+prob = gar.LqrProblem(knots, nx)
 prob.G0 = -np.eye(nx)
 prob.g0 = x0
 

--- a/examples/gar-lqr-join.py
+++ b/examples/gar-lqr-join.py
@@ -28,7 +28,7 @@ r_ = np.random.randn(nu)
 
 
 def knot_get_default(nx, nu, nc):
-    knot = gar.LQRKnot(nx, nu, nc)
+    knot = gar.LqrKnot(nx, nu, nc)
     knot.Q[:] = Q_
     knot.q[:] = -Q_ @ xbar
     knot.R[:] = np.eye(nu) * 0.1
@@ -49,7 +49,7 @@ for t in range(t0):
 
 mu = 1e-12
 
-prob1 = gar.LQRProblem(knots, nx)
+prob1 = gar.LqrProblem(knots, nx)
 prob1.G0 = -np.eye(nx)
 prob1.g0 = x0
 prob1.addParameterization(nx)
@@ -64,7 +64,7 @@ solver1.backward(mu, mu)
 
 
 knots.append(knot_get_default(nx, 0, 0))
-prob2 = gar.LQRProblem(knots, 0)
+prob2 = gar.LqrProblem(knots, 0)
 prob2.addParameterization(nx)
 knots2 = prob2.stages
 knots2[0].Gx = E_.T
@@ -117,7 +117,7 @@ us3 = sol3["us"]
 
 # compute error
 def computeError():
-    kn: gar.LQRKnot = knots1[-1]
+    kn: gar.LqrKnot = knots1[-1]
     knp = knots1[-2]
     x_ = xs1[-1]
     u_ = us1[-1]
@@ -144,7 +144,7 @@ def computeError():
     print("gu:", gu)
     print("gx:", gx)
     # second leg
-    knn: gar.LQRKnot = knots2[0]
+    knn: gar.LqrKnot = knots2[0]
     gxn = knn.q + knn.Q @ xs2[0] + knn.S @ us2[0] + knn.A.T @ ls2[1]
     gxn += kn.E.T @ thopt
     print("gxn:", gxn)

--- a/gar/include/aligator/gar/cholmod-solver.hpp
+++ b/gar/include/aligator/gar/cholmod-solver.hpp
@@ -15,7 +15,7 @@ template <typename _Scalar> class CholmodLqSolver {
 public:
   using Scalar = _Scalar;
   ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
-  using Problem = LQRProblemTpl<Scalar>;
+  using Problem = LqrProblemTpl<Scalar>;
   using SparseType = Eigen::SparseMatrix<Scalar>;
   using Triplet = Eigen::Triplet<Scalar>;
 

--- a/gar/include/aligator/gar/dense-riccati.hpp
+++ b/gar/include/aligator/gar/dense-riccati.hpp
@@ -22,7 +22,7 @@ public:
   using BlkMat44 = BlkMatrix<MatrixXs, 4, 4>;
   using BlkRowMat41 = BlkMatrix<RowMatrixXs, 4, 1>;
   using BlkVec4 = BlkMatrix<VectorXs, 4, 1>;
-  using KnotType = LQRKnotTpl<Scalar>;
+  using KnotType = LqrKnotTpl<Scalar>;
 
   std::vector<BlkMat44> kkts;
   std::vector<BlkVec4> ffs;
@@ -43,7 +43,7 @@ public:
   VectorXs thGrad;
   MatrixXs thHess;
 
-  explicit RiccatiSolverDense(const LQRProblemTpl<Scalar> &problem);
+  explicit RiccatiSolverDense(const LqrProblemTpl<Scalar> &problem);
 
   bool backward(const Scalar mudyn, const Scalar mueq);
 
@@ -56,9 +56,9 @@ public:
   RowMatrixRef getFeedback(size_t i) { return fbs[i].matrix(); }
 
 protected:
-  void init_factor(const LQRKnotTpl<Scalar> &knot);
+  void init_factor(const LqrKnotTpl<Scalar> &knot);
   void initialize();
-  const LQRProblemTpl<Scalar> *problem_;
+  const LqrProblemTpl<Scalar> *problem_;
 };
 
 } // namespace aligator::gar

--- a/gar/include/aligator/gar/dense-riccati.hxx
+++ b/gar/include/aligator/gar/dense-riccati.hxx
@@ -10,7 +10,7 @@
 namespace aligator::gar {
 
 template <typename Scalar>
-void RiccatiSolverDense<Scalar>::init_factor(const LQRKnotTpl<Scalar> &knot) {
+void RiccatiSolverDense<Scalar>::init_factor(const LqrKnotTpl<Scalar> &knot) {
   std::array<long, 4> dims = {knot.nu, knot.nc, knot.nx2, knot.nx2};
   long ntot = dims[0] + dims[1] + dims[2] + dims[3];
   kkts.emplace_back(BlkMat44::Zero(dims, dims));
@@ -22,7 +22,7 @@ void RiccatiSolverDense<Scalar>::init_factor(const LQRKnotTpl<Scalar> &knot) {
 
 template <typename Scalar>
 RiccatiSolverDense<Scalar>::RiccatiSolverDense(
-    const LQRProblemTpl<Scalar> &problem)
+    const LqrProblemTpl<Scalar> &problem)
     : Base(), problem_(&problem) {
   initialize();
 }

--- a/gar/include/aligator/gar/lqr-problem.hpp
+++ b/gar/include/aligator/gar/lqr-problem.hpp
@@ -25,7 +25,7 @@ namespace gar {
 ///   Cx + Du + d = 0.
 /// \f\]
 ///
-template <typename Scalar> struct LQRKnotTpl {
+template <typename Scalar> struct LqrKnotTpl {
   ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
 
   uint nx, nu, nc, nx2, nth;
@@ -42,23 +42,23 @@ template <typename Scalar> struct LQRKnotTpl {
   MatrixXs Gv;
   VectorXs gamma;
 
-  LQRKnotTpl(uint nx, uint nu, uint nc, uint nx2, uint nth = 0);
+  LqrKnotTpl(uint nx, uint nu, uint nc, uint nx2, uint nth = 0);
 
-  LQRKnotTpl(uint nx, uint nu, uint nc) : LQRKnotTpl(nx, nu, nc, nx) {}
+  LqrKnotTpl(uint nx, uint nu, uint nc) : LqrKnotTpl(nx, nu, nc, nx) {}
 
   // reallocates entire buffer for contigousness
   void addParameterization(uint nth);
-  bool isApprox(const LQRKnotTpl &other,
+  bool isApprox(const LqrKnotTpl &other,
                 Scalar prec = std::numeric_limits<Scalar>::epsilon()) const;
 
-  friend bool operator==(const LQRKnotTpl &lhs, const LQRKnotTpl &rhs) {
+  friend bool operator==(const LqrKnotTpl &lhs, const LqrKnotTpl &rhs) {
     return lhs.isApprox(rhs);
   }
 };
 
-template <typename Scalar> struct LQRProblemTpl {
+template <typename Scalar> struct LqrProblemTpl {
   ALIGATOR_DYNAMIC_TYPEDEFS(Scalar);
-  using KnotType = LQRKnotTpl<Scalar>;
+  using KnotType = LqrKnotTpl<Scalar>;
   using KnotVector = std::vector<KnotType>;
   KnotVector stages;
   MatrixXs G0;
@@ -67,13 +67,13 @@ template <typename Scalar> struct LQRProblemTpl {
   inline int horizon() const noexcept { return int(stages.size()) - 1; }
   inline uint nc0() const noexcept { return (uint)g0.rows(); }
 
-  LQRProblemTpl() : stages(), G0(), g0() {}
+  LqrProblemTpl() : stages(), G0(), g0() {}
 
-  LQRProblemTpl(KnotVector &&knots, long nc0) : stages(knots), G0(), g0(nc0) {
+  LqrProblemTpl(KnotVector &&knots, long nc0) : stages(knots), G0(), g0(nc0) {
     initialize();
   }
 
-  LQRProblemTpl(const KnotVector &knots, long nc0)
+  LqrProblemTpl(const KnotVector &knots, long nc0)
       : stages(knots), G0(), g0(nc0) {
     initialize();
   }
@@ -107,8 +107,8 @@ protected:
 };
 
 template <typename Scalar>
-std::ostream &operator<<(std::ostream &oss, const LQRKnotTpl<Scalar> &self) {
-  oss << "LQRKnot {";
+std::ostream &operator<<(std::ostream &oss, const LqrKnotTpl<Scalar> &self) {
+  oss << "LqrKnot {";
   oss << fmt::format("\n  nx:  {:d}", self.nx) //
       << fmt::format("\n  nu:  {:d}", self.nu) //
       << fmt::format("\n  nc:  {:d}", self.nc);

--- a/gar/include/aligator/gar/lqr-problem.hxx
+++ b/gar/include/aligator/gar/lqr-problem.hxx
@@ -5,7 +5,7 @@
 namespace aligator::gar {
 
 template <typename Scalar>
-LQRKnotTpl<Scalar>::LQRKnotTpl(uint nx, uint nu, uint nc, uint nx2, uint nth)
+LqrKnotTpl<Scalar>::LqrKnotTpl(uint nx, uint nu, uint nc, uint nx2, uint nth)
     : nx(nx), nu(nu), nc(nc), nx2(nx2), nth(nth),    //
       Q(nx, nx), S(nx, nu), R(nu, nu), q(nx), r(nu), //
       A(nx2, nx), B(nx2, nu), E(nx2, nx), f(nx2),    //
@@ -34,7 +34,7 @@ LQRKnotTpl<Scalar>::LQRKnotTpl(uint nx, uint nu, uint nc, uint nx2, uint nth)
 }
 
 template <typename Scalar>
-void LQRKnotTpl<Scalar>::addParameterization(uint nth) {
+void LqrKnotTpl<Scalar>::addParameterization(uint nth) {
   this->nth = nth;
   Gth.setZero(nth, nth);
   Gx.setZero(nx, nth);
@@ -44,7 +44,7 @@ void LQRKnotTpl<Scalar>::addParameterization(uint nth) {
 }
 
 template <typename Scalar>
-bool LQRKnotTpl<Scalar>::isApprox(const LQRKnotTpl &other, Scalar prec) const {
+bool LqrKnotTpl<Scalar>::isApprox(const LqrKnotTpl &other, Scalar prec) const {
   bool cost = Q.isApprox(other.Q, prec) && S.isApprox(other.S, prec) &&
               R.isApprox(other.R, prec) && q.isApprox(other.q, prec) &&
               r.isApprox(other.r, prec);
@@ -59,7 +59,7 @@ bool LQRKnotTpl<Scalar>::isApprox(const LQRKnotTpl &other, Scalar prec) const {
 }
 
 template <typename Scalar>
-Scalar LQRProblemTpl<Scalar>::evaluate(
+Scalar LqrProblemTpl<Scalar>::evaluate(
     const VectorOfVectors &xs, const VectorOfVectors &us,
     const std::optional<ConstVectorRef> &theta_) const {
   if ((int)xs.size() != horizon() + 1)
@@ -72,7 +72,7 @@ Scalar LQRProblemTpl<Scalar>::evaluate(
 
   Scalar ret = 0.;
   for (uint i = 0; i <= (uint)horizon(); i++) {
-    const LQRKnotTpl<Scalar> &knot = stages[i];
+    const LqrKnotTpl<Scalar> &knot = stages[i];
     ret += 0.5 * xs[i].dot(knot.Q * xs[i]) + xs[i].dot(knot.q);
     if (i == (uint)horizon())
       break;
@@ -86,7 +86,7 @@ Scalar LQRProblemTpl<Scalar>::evaluate(
   if (theta_.has_value()) {
     ConstVectorRef th = theta_.value();
     for (uint i = 0; i <= (uint)horizon(); i++) {
-      const LQRKnotTpl<Scalar> &knot = stages[i];
+      const LqrKnotTpl<Scalar> &knot = stages[i];
       ret += 0.5 * th.dot(knot.Gth * th);
       ret += th.dot(knot.Gx.transpose() * xs[i]);
       ret += th.dot(knot.gamma);

--- a/gar/include/aligator/gar/lqr-problem.txx
+++ b/gar/include/aligator/gar/lqr-problem.txx
@@ -6,7 +6,7 @@
 
 namespace aligator {
 namespace gar {
-extern template struct LQRKnotTpl<context::Scalar>;
-extern template struct LQRProblemTpl<context::Scalar>;
+extern template struct LqrKnotTpl<context::Scalar>;
+extern template struct LqrProblemTpl<context::Scalar>;
 } // namespace gar
 } // namespace aligator

--- a/gar/include/aligator/gar/parallel-solver.hpp
+++ b/gar/include/aligator/gar/parallel-solver.hpp
@@ -28,12 +28,12 @@ public:
   StageFactorVec datas;
 
   using Impl = ProximalRiccatiKernel<Scalar>;
-  using KnotType = LQRKnotTpl<Scalar>;
+  using KnotType = LqrKnotTpl<Scalar>;
 
   using BlkMat = BlkMatrix<MatrixXs, -1, -1>;
   using BlkVec = BlkMatrix<VectorXs, -1, 1>;
 
-  explicit ParallelRiccatiSolver(LQRProblemTpl<Scalar> &problem,
+  explicit ParallelRiccatiSolver(LqrProblemTpl<Scalar> &problem,
                                  const uint num_threads);
 
   void allocateLeg(uint start, uint end, bool last_leg);
@@ -100,7 +100,7 @@ public:
   void initializeTridiagSystem(const std::vector<long> &dims);
 
 protected:
-  LQRProblemTpl<Scalar> *problem_;
+  LqrProblemTpl<Scalar> *problem_;
 };
 #endif
 

--- a/gar/include/aligator/gar/parallel-solver.hxx
+++ b/gar/include/aligator/gar/parallel-solver.hxx
@@ -16,7 +16,7 @@ namespace aligator::gar {
 #ifdef ALIGATOR_MULTITHREADING
 template <typename Scalar>
 ParallelRiccatiSolver<Scalar>::ParallelRiccatiSolver(
-    LQRProblemTpl<Scalar> &problem, const uint num_threads)
+    LqrProblemTpl<Scalar> &problem, const uint num_threads)
     : Base(), numThreads(num_threads), problem_(&problem) {
   ALIGATOR_TRACY_ZONE_SCOPED;
   if (num_threads < 2) {

--- a/gar/include/aligator/gar/proximal-riccati.hpp
+++ b/gar/include/aligator/gar/proximal-riccati.hpp
@@ -20,9 +20,9 @@ public:
   using StageFactorType = StageFactor<Scalar>;
   using value_t = typename StageFactorType::value_t;
   using kkt0_t = typename Impl::kkt0_t;
-  using KnotType = LQRKnotTpl<Scalar>;
+  using KnotType = LqrKnotTpl<Scalar>;
 
-  explicit ProximalRiccatiSolver(const LQRProblemTpl<Scalar> &problem);
+  explicit ProximalRiccatiSolver(const LqrProblemTpl<Scalar> &problem);
 
   /// Backward sweep.
   bool backward(const Scalar mudyn, const Scalar mueq);
@@ -40,7 +40,7 @@ public:
   MatrixXs thHess; //< optimal value Hessian wrt parameter
 
 protected:
-  const LQRProblemTpl<Scalar> *problem_;
+  const LqrProblemTpl<Scalar> *problem_;
 };
 
 } // namespace gar

--- a/gar/include/aligator/gar/proximal-riccati.hxx
+++ b/gar/include/aligator/gar/proximal-riccati.hxx
@@ -10,7 +10,7 @@ namespace aligator::gar {
 
 template <typename Scalar>
 ProximalRiccatiSolver<Scalar>::ProximalRiccatiSolver(
-    const LQRProblemTpl<Scalar> &problem)
+    const LqrProblemTpl<Scalar> &problem)
     : Base(), kkt0(problem.stages[0].nx, problem.nc0(), problem.ntheta()),
       thGrad(problem.ntheta()), thHess(problem.ntheta(), problem.ntheta()),
       problem_(&problem) {

--- a/gar/include/aligator/gar/riccati-base.hpp
+++ b/gar/include/aligator/gar/riccati-base.hpp
@@ -12,7 +12,7 @@ namespace gar {
 template <typename _Scalar> class RiccatiSolverBase {
 public:
   using Scalar = _Scalar;
-  using LQRKnot = LQRKnotTpl<double>;
+  using LqrKnot = LqrKnotTpl<double>;
   ALIGATOR_DYNAMIC_TYPEDEFS_WITH_ROW_TYPES(Scalar);
 
   virtual bool backward(const Scalar mudyn, const Scalar mueq) = 0;
@@ -22,7 +22,7 @@ public:
           std::vector<VectorXs> &vs, std::vector<VectorXs> &lbdas,
           const std::optional<ConstVectorRef> &theta_ = std::nullopt) const = 0;
 
-  virtual void cycleAppend(const LQRKnot &knot) = 0;
+  virtual void cycleAppend(const LqrKnot &knot) = 0;
 
   /// For applicable solvers, updates the first feedback gain in-place to
   /// correspond to the first Riccati gain.

--- a/gar/include/aligator/gar/riccati-impl.hpp
+++ b/gar/include/aligator/gar/riccati-impl.hpp
@@ -14,8 +14,8 @@
 
 namespace aligator {
 namespace gar {
-template <typename Scalar> struct LQRKnotTpl;
-template <typename Scalar> struct LQRProblemTpl;
+template <typename Scalar> struct LqrKnotTpl;
+template <typename Scalar> struct LqrProblemTpl;
 
 /// Create a boost::span object from a vector and two indices.
 template <class T, class A>
@@ -93,7 +93,7 @@ template <typename Scalar> struct ProximalRiccatiKernel {
   using RowMatrixXs = Eigen::Matrix<Scalar, -1, -1, Eigen::RowMajor>;
   using RowMatrixRef = Eigen::Ref<RowMatrixXs>;
   using ConstRowMatrixRef = Eigen::Ref<const RowMatrixXs>;
-  using KnotType = LQRKnotTpl<Scalar>;
+  using KnotType = LqrKnotTpl<Scalar>;
   using StageFactorType = StageFactor<Scalar>;
   using value_t = typename StageFactor<Scalar>::value_t;
 

--- a/gar/include/aligator/gar/utils.hpp
+++ b/gar/include/aligator/gar/utils.hpp
@@ -43,14 +43,14 @@ void sparseAssignDiagonal(Eigen::Index i0, Eigen::Index i1, Scalar value,
 } // namespace helpers
 
 template <typename Scalar>
-void lqrCreateSparseMatrix(const LQRProblemTpl<Scalar> &problem,
+void lqrCreateSparseMatrix(const LqrProblemTpl<Scalar> &problem,
                            const Scalar mudyn, const Scalar mueq,
                            Eigen::SparseMatrix<Scalar> &mat,
                            Eigen::Matrix<Scalar, -1, 1> &rhs, bool update);
 
 template <typename Scalar>
 std::array<Scalar, 3> lqrComputeKktError(
-    const LQRProblemTpl<Scalar> &problem,
+    const LqrProblemTpl<Scalar> &problem,
     boost::span<const typename math_types<Scalar>::VectorXs> xs,
     boost::span<const typename math_types<Scalar>::VectorXs> us,
     boost::span<const typename math_types<Scalar>::VectorXs> vs,
@@ -63,13 +63,13 @@ std::array<Scalar, 3> lqrComputeKktError(
 /// with the given dual-regularization parameters @p mudyn and @p mueq.
 /// @returns Whether the matrices were successfully allocated.
 template <typename Scalar>
-bool lqrDenseMatrix(const LQRProblemTpl<Scalar> &problem, Scalar mudyn,
+bool lqrDenseMatrix(const LqrProblemTpl<Scalar> &problem, Scalar mudyn,
                     Scalar mueq, typename math_types<Scalar>::MatrixXs &mat,
                     typename math_types<Scalar>::VectorXs &rhs);
 
 /// @brief Compute the number of rows in the problem matrix.
 template <typename Scalar>
-uint lqrNumRows(const LQRProblemTpl<Scalar> &problem) {
+uint lqrNumRows(const LqrProblemTpl<Scalar> &problem) {
   const auto &knots = problem.stages;
   const uint nc0 = problem.nc0();
   const size_t N = knots.size() - 1UL;
@@ -85,7 +85,7 @@ uint lqrNumRows(const LQRProblemTpl<Scalar> &problem) {
 
 /// @copybrief lqrDenseMatrix()
 template <typename Scalar>
-auto lqrDenseMatrix(const LQRProblemTpl<Scalar> &problem, Scalar mudyn,
+auto lqrDenseMatrix(const LqrProblemTpl<Scalar> &problem, Scalar mudyn,
                     Scalar mueq) {
 
   decltype(auto) knots = problem.stages;
@@ -105,7 +105,7 @@ auto lqrDenseMatrix(const LQRProblemTpl<Scalar> &problem, Scalar mudyn,
 /// @brief Convert dense RHS solution to its trajectory [x,u,v,lambda] solution.
 template <typename Scalar>
 void lqrDenseSolutionToTraj(
-    const LQRProblemTpl<Scalar> &problem,
+    const LqrProblemTpl<Scalar> &problem,
     const typename math_types<Scalar>::ConstVectorRef solution,
     std::vector<typename math_types<Scalar>::VectorXs> &xs,
     std::vector<typename math_types<Scalar>::VectorXs> &us,
@@ -122,7 +122,7 @@ void lqrDenseSolutionToTraj(
 
   uint idx = nc0;
   for (size_t t = 0; t <= N; t++) {
-    const LQRKnotTpl<Scalar> &knot = problem.stages[t];
+    const LqrKnotTpl<Scalar> &knot = problem.stages[t];
     const uint n = knot.nx + knot.nu + knot.nc;
     auto seg = solution.segment(idx, n);
     xs[t] = seg.head(knot.nx);
@@ -137,9 +137,9 @@ void lqrDenseSolutionToTraj(
 }
 
 template <typename Scalar>
-auto lqrInitializeSolution(const LQRProblemTpl<Scalar> &problem) {
+auto lqrInitializeSolution(const LqrProblemTpl<Scalar> &problem) {
   using VectorXs = typename math_types<Scalar>::VectorXs;
-  using knot_t = LQRKnotTpl<Scalar>;
+  using knot_t = LqrKnotTpl<Scalar>;
   std::vector<VectorXs> xs;
   std::vector<VectorXs> us;
   std::vector<VectorXs> vs;
@@ -170,18 +170,18 @@ auto lqrInitializeSolution(const LQRProblemTpl<Scalar> &problem) {
 
 #ifdef ALIGATOR_ENABLE_TEMPLATE_INSTANTIATION
 extern template void lqrCreateSparseMatrix<context::Scalar>(
-    const LQRProblemTpl<context::Scalar> &problem, const context::Scalar mudyn,
+    const LqrProblemTpl<context::Scalar> &problem, const context::Scalar mudyn,
     const context::Scalar mueq, Eigen::SparseMatrix<context::Scalar> &mat,
     context::VectorXs &rhs, bool update);
 extern template std::array<context::Scalar, 3>
 lqrComputeKktError<context::Scalar>(
-    const LQRProblemTpl<context::Scalar> &,
+    const LqrProblemTpl<context::Scalar> &,
     boost::span<const context::VectorXs>, boost::span<const context::VectorXs>,
     boost::span<const context::VectorXs>, boost::span<const context::VectorXs>,
     const context::Scalar, const context::Scalar,
     const std::optional<context::ConstVectorRef> &, bool);
 extern template auto
-lqrDenseMatrix<context::Scalar>(const LQRProblemTpl<context::Scalar> &,
+lqrDenseMatrix<context::Scalar>(const LqrProblemTpl<context::Scalar> &,
                                 context::Scalar, context::Scalar);
 #endif
 

--- a/gar/include/aligator/gar/utils.hxx
+++ b/gar/include/aligator/gar/utils.hxx
@@ -4,13 +4,13 @@
 namespace aligator::gar {
 
 template <typename Scalar>
-void lqrCreateSparseMatrix(const LQRProblemTpl<Scalar> &problem,
+void lqrCreateSparseMatrix(const LqrProblemTpl<Scalar> &problem,
                            const Scalar mudyn, const Scalar mueq,
                            Eigen::SparseMatrix<Scalar> &mat,
                            Eigen::Matrix<Scalar, -1, 1> &rhs, bool update) {
   using Eigen::Index;
   const uint nrows = lqrNumRows(problem);
-  using knot_t = LQRKnotTpl<Scalar>;
+  using knot_t = LqrKnotTpl<Scalar>;
   const auto &knots = problem.stages;
 
   if (!update) {
@@ -93,7 +93,7 @@ void lqrCreateSparseMatrix(const LQRProblemTpl<Scalar> &problem,
 
 template <typename Scalar>
 std::array<Scalar, 3> lqrComputeKktError(
-    const LQRProblemTpl<Scalar> &problem,
+    const LqrProblemTpl<Scalar> &problem,
     boost::span<const typename math_types<Scalar>::VectorXs> xs,
     boost::span<const typename math_types<Scalar>::VectorXs> us,
     boost::span<const typename math_types<Scalar>::VectorXs> vs,
@@ -106,7 +106,7 @@ std::array<Scalar, 3> lqrComputeKktError(
   uint N = (uint)problem.horizon();
   assert(xs.size() == N + 1);
   using VectorXs = typename math_types<Scalar>::VectorXs;
-  using KnotType = LQRKnotTpl<Scalar>;
+  using KnotType = LqrKnotTpl<Scalar>;
 
   Scalar dynErr = 0.;
   Scalar cstErr = 0.;
@@ -192,10 +192,10 @@ std::array<Scalar, 3> lqrComputeKktError(
 }
 
 template <typename Scalar>
-bool lqrDenseMatrix(const LQRProblemTpl<Scalar> &problem, Scalar mudyn,
+bool lqrDenseMatrix(const LqrProblemTpl<Scalar> &problem, Scalar mudyn,
                     Scalar mueq, typename math_types<Scalar>::MatrixXs &mat,
                     typename math_types<Scalar>::VectorXs &rhs) {
-  using knot_t = LQRKnotTpl<Scalar>;
+  using knot_t = LqrKnotTpl<Scalar>;
   const auto &knots = problem.stages;
   const size_t N = size_t(problem.horizon());
 

--- a/gar/src/lqr-problem.cpp
+++ b/gar/src/lqr-problem.cpp
@@ -3,7 +3,7 @@
 
 namespace aligator {
 namespace gar {
-template struct LQRKnotTpl<context::Scalar>;
-template struct LQRProblemTpl<context::Scalar>;
+template struct LqrKnotTpl<context::Scalar>;
+template struct LqrProblemTpl<context::Scalar>;
 } // namespace gar
 } // namespace aligator

--- a/gar/src/utils.cpp
+++ b/gar/src/utils.cpp
@@ -4,17 +4,17 @@
 namespace aligator {
 namespace gar {
 template void lqrCreateSparseMatrix<context::Scalar>(
-    const LQRProblemTpl<context::Scalar> &problem, const context::Scalar mudyn,
+    const LqrProblemTpl<context::Scalar> &problem, const context::Scalar mudyn,
     const context::Scalar mueq, Eigen::SparseMatrix<context::Scalar> &mat,
     context::VectorXs &rhs, bool update);
 template std::array<context::Scalar, 3> lqrComputeKktError<context::Scalar>(
-    const LQRProblemTpl<context::Scalar> &,
+    const LqrProblemTpl<context::Scalar> &,
     boost::span<const context::VectorXs>, boost::span<const context::VectorXs>,
     boost::span<const context::VectorXs>, boost::span<const context::VectorXs>,
     const context::Scalar, const context::Scalar,
     const std::optional<context::ConstVectorRef> &, bool);
 template auto
-lqrDenseMatrix<context::Scalar>(const LQRProblemTpl<context::Scalar> &,
+lqrDenseMatrix<context::Scalar>(const LqrProblemTpl<context::Scalar> &,
                                 context::Scalar, context::Scalar);
 } // namespace gar
 } // namespace aligator

--- a/include/aligator/solvers/proxddp/solver-proxddp.hxx
+++ b/include/aligator/solvers/proxddp/solver-proxddp.hxx
@@ -797,17 +797,17 @@ void SolverProxDDPTpl<Scalar>::registerCallback(const std::string &name,
 template <typename Scalar> void SolverProxDDPTpl<Scalar>::updateLQSubproblem() {
   ALIGATOR_NOMALLOC_SCOPED;
   ALIGATOR_TRACY_ZONE_SCOPED;
-  gar::LQRProblemTpl<Scalar> &prob = workspace_.lqr_problem;
+  gar::LqrProblemTpl<Scalar> &prob = workspace_.lqr_problem;
   const TrajOptData &pd = workspace_.problem_data;
 
-  using gar::LQRKnotTpl;
+  using gar::LqrKnotTpl;
 
   size_t N = (size_t)prob.horizon();
   assert(N == workspace_.nsteps);
 
   for (size_t t = 0; t < N; t++) {
     const StageData &sd = *pd.stage_data[t];
-    LQRKnotTpl<Scalar> &knot = prob.stages[t];
+    LqrKnotTpl<Scalar> &knot = prob.stages[t];
     const DynamicsData &dd = *sd.dynamics_data;
     const CostData &cd = *sd.cost_data;
     uint nx = knot.nx;
@@ -847,7 +847,7 @@ template <typename Scalar> void SolverProxDDPTpl<Scalar>::updateLQSubproblem() {
   }
 
   {
-    LQRKnotTpl<Scalar> &knot = prob.stages[N];
+    LqrKnotTpl<Scalar> &knot = prob.stages[N];
     const CostData &tcd = *pd.term_cost_data;
     knot.Q = tcd.Lxx_;
     knot.Q.diagonal().array() += preg_;
@@ -862,7 +862,7 @@ template <typename Scalar> void SolverProxDDPTpl<Scalar>::updateLQSubproblem() {
   prob.G0 = id.Jx_;
   prob.g0.noalias() = workspace_.Lds[0];
 
-  LQRKnotTpl<Scalar> &model = prob.stages[0];
+  LqrKnotTpl<Scalar> &model = prob.stages[0];
   model.Q += id.Hxx_;
 }
 

--- a/include/aligator/solvers/proxddp/workspace.hpp
+++ b/include/aligator/solvers/proxddp/workspace.hpp
@@ -30,17 +30,17 @@ template <typename Scalar> struct WorkspaceTpl : WorkspaceBaseTpl<Scalar> {
   using StageModel = StageModelTpl<Scalar>;
   using Base = WorkspaceBaseTpl<Scalar>;
   using VecBool = Eigen::Matrix<bool, Eigen::Dynamic, 1>;
-  using KnotType = gar::LQRKnotTpl<Scalar>;
+  using KnotType = gar::LqrKnotTpl<Scalar>;
   using ConstraintSetProduct = proxsuite::nlp::ConstraintSetProductTpl<Scalar>;
   using BlkJacobianType = BlkMatrix<MatrixXs, -1, 2>; // jacobians
-  using LQRProblemType = gar::LQRProblemTpl<Scalar>;
+  using LqrProblemType = gar::LqrProblemTpl<Scalar>;
 
   using Base::dyn_slacks;
   using Base::nsteps;
   using Base::problem_data;
 
-  typename LQRProblemType::KnotVector knots;
-  gar::LQRProblemTpl<Scalar> lqr_problem; //< Linear-quadratic subproblem
+  typename LqrProblemType::KnotVector knots;
+  gar::LqrProblemTpl<Scalar> lqr_problem; //< Linear-quadratic subproblem
 
   /// @name Lagrangian Gradients
   /// @{

--- a/include/aligator/solvers/proxddp/workspace.hxx
+++ b/include/aligator/solvers/proxddp/workspace.hxx
@@ -69,7 +69,7 @@ WorkspaceTpl<Scalar>::WorkspaceTpl(const TrajOptProblemTpl<Scalar> &problem)
 
   // initial condition
   long nc0 = (long)problem.init_constraint_->nr;
-  lqr_problem = LQRProblemType(knots, nc0);
+  lqr_problem = LqrProblemType(knots, nc0);
   std::tie(dxs, dus, dvs, dlams) =
       gar::lqrInitializeSolution(lqr_problem); // lqr subproblem variables
   Lxs = dxs;
@@ -116,7 +116,7 @@ void WorkspaceTpl<Scalar>::cycleAppend(const TrajOptProblemTpl<Scalar> &problem,
 
   shifted_constraints = prev_vs;
   rotate_vec_left(knots, 0, 1);
-  knots[nsteps - 1] = gar::LQRKnotTpl<double>(
+  knots[nsteps - 1] = gar::LqrKnotTpl<double>(
       uint(stage.ndx1()), uint(stage.nu()), uint(stage.nc()));
 
   rotate_vec_left(cstr_product_sets, 0, 1);
@@ -130,7 +130,7 @@ void WorkspaceTpl<Scalar>::cycleAppend(const TrajOptProblemTpl<Scalar> &problem,
 
   // initial condition
   long nc0 = (long)problem.init_constraint_->nr;
-  lqr_problem = LQRProblemType(knots, nc0);
+  lqr_problem = LqrProblemType(knots, nc0);
   std::tie(dxs, dus, dvs, dlams) =
       gar::lqrInitializeSolution(lqr_problem); // lqr subproblem variables
 

--- a/tests/gar/test_util.hpp
+++ b/tests/gar/test_util.hpp
@@ -5,8 +5,8 @@
 #include <random>
 
 ALIGATOR_DYNAMIC_TYPEDEFS(double);
-using problem_t = aligator::gar::LQRProblemTpl<double>;
-using knot_t = aligator::gar::LQRKnotTpl<double>;
+using problem_t = aligator::gar::LqrProblemTpl<double>;
+using knot_t = aligator::gar::LqrKnotTpl<double>;
 using aligator::math::infty_norm;
 
 struct KktError {


### PR DESCRIPTION
This is a tiny PR, cut off from contents of #243 

- Rename `LQRKnotTpl` (C++)/`LqrKnot` (Python) to `LqrKnot(Tpl)`
- Rename `LQRProblemTpl` (C++)/`LQRProblem` (Python) to `LqrProblem(Tpl)`