### PR TITLE
macos-linux-pixi workflow: change branch rules

### DIFF
--- a/.github/workflows/macos-linux-pixi.yml
+++ b/.github/workflows/macos-linux-pixi.yml
@@ -2,6 +2,9 @@ name: CI - OSX/Linux via Pixi
 
 on:
   push:
+    branches:
+      - main
+      - devel
     paths-ignore:
       - 'doc/**'
       - 'scripts/**'


### PR DESCRIPTION
Only run workflow on push for `main` and `devel` branches.