### PR TITLE
Fix segfault in `FrameCollisionResidual`, add corresponding test in `test_frames.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add macro `ALIGATOR_OUT_OF_RANGE_ERROR` to throw `std::out_of_range` exceptions ([#294](https://github.com/Simple-Robotics/aligator/pull/294))
+
 ### Changed
 
 - Rename `LQRKnotTpl` (C++)/`LqrKnot` (Python) to `LqrKnot(Tpl)`
@@ -16,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Correct references to paper's equations ([#284](https://github.com/Simple-Robotics/aligator/pull/284))
+- Fix segfault in `FrameCollisionResidual`, instead throw `std::runtime_error` (**C++**, `RuntimeError` in **Python**) ([#294](https://github.com/Simple-Robotics/aligator/pull/294))
 
 ## [0.12.0] - 2025-03-27
 

--- a/bindings/python/src/modelling/expose-pinocchio-functions.cpp
+++ b/bindings/python/src/modelling/expose-pinocchio-functions.cpp
@@ -142,7 +142,7 @@ void exposeFrameFunctions() {
       bp::no_init)
       .def_readonly("pin_data", &FrameCollisionData::pin_data_,
                     "Pinocchio data struct.")
-      .def_readonly("geom_data", &FrameCollisionData::geometry_,
+      .def_readonly("geom_data", &FrameCollisionData::geom_data,
                     "Geometry data struct.");
 }
 

--- a/include/aligator/modelling/multibody/frame-collision.hpp
+++ b/include/aligator/modelling/multibody/frame-collision.hpp
@@ -64,23 +64,21 @@ template <typename Scalar>
 struct FrameCollisionDataTpl : StageFunctionDataTpl<Scalar> {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
   using Base = StageFunctionDataTpl<Scalar>;
-  using PinData = pinocchio::DataTpl<Scalar>;
-  using PinGeom = pinocchio::GeometryData;
-  using pinPlacement = pinocchio::SE3;
+  using typename Base::Matrix6Xs;
+  using typename Base::Vector3s;
+  using SE3 = pinocchio::SE3Tpl<Scalar>;
 
-  /// Pinocchio data object
-  PinData pin_data_;
-  /// Pinocchio geometry object
-  pinocchio::GeometryData geometry_;
+  pinocchio::DataTpl<Scalar> pin_data_;
+  pinocchio::GeometryData geom_data;
   /// Jacobian of the collision point
-  typename math_types<Scalar>::Matrix6Xs Jcol_;
-  typename math_types<Scalar>::Matrix6Xs Jcol2_;
+  Matrix6Xs Jcol_;
+  Matrix6Xs Jcol2_;
   /// Placement of collision point to joint
-  pinPlacement jointToP1_;
-  pinPlacement jointToP2_;
+  SE3 jointToP1_;
+  SE3 jointToP2_;
   /// Distance from nearest point to joint for each collision frame
-  typename math_types<Scalar>::Vector3s distance_;
-  typename math_types<Scalar>::Vector3s distance2_;
+  Vector3s distance_;
+  Vector3s distance2_;
 
   FrameCollisionDataTpl(const FrameCollisionResidualTpl<Scalar> &model);
 };

--- a/include/aligator/modelling/multibody/frame-collision.hpp
+++ b/include/aligator/modelling/multibody/frame-collision.hpp
@@ -23,7 +23,6 @@ public:
   ALIGATOR_UNARY_FUNCTION_INTERFACE(Scalar);
   using BaseData = typename Base::Data;
   using Model = pinocchio::ModelTpl<Scalar>;
-  using ManifoldPtr = xyz::polymorphic<ManifoldAbstractTpl<Scalar>>;
   using SE3 = pinocchio::SE3Tpl<Scalar>;
   using Data = FrameCollisionDataTpl<Scalar>;
   using GeometryModel = pinocchio::GeometryModel;
@@ -36,6 +35,12 @@ public:
                             const pinocchio::PairIndex frame_pair_id)
       : Base(ndx, nu, 1), pin_model_(model), geom_model_(geom_model),
         frame_pair_id_(frame_pair_id) {
+    if (frame_pair_id >= geom_model_.collisionPairs.size()) {
+      ALIGATOR_OUT_OF_RANGE_ERROR(
+          "Provided collision pair index {:d} is not valid "
+          "(geom model has {:d} pairs).",
+          frame_pair_id, geom_model.collisionPairs.size());
+    }
     frame_id1_ =
         geom_model
             .geometryObjects[geom_model.collisionPairs[frame_pair_id_].first]

--- a/include/aligator/modelling/multibody/frame-collision.hxx
+++ b/include/aligator/modelling/multibody/frame-collision.hxx
@@ -18,11 +18,11 @@ void FrameCollisionResidualTpl<Scalar>::evaluate(const ConstVectorRef &x,
 
   // computes the collision distance between pair of frames
   pinocchio::updateGeometryPlacements(pin_model_, pdata, geom_model_,
-                                      d.geometry_, x.head(pin_model_.nq));
-  pinocchio::computeDistance(geom_model_, d.geometry_, frame_pair_id_);
+                                      d.geom_data, x.head(pin_model_.nq));
+  pinocchio::computeDistance(geom_model_, d.geom_data, frame_pair_id_);
 
   // calculate residual
-  d.value_[0] = d.geometry_.distanceResults[frame_pair_id_].min_distance;
+  d.value_[0] = d.geom_data.distanceResults[frame_pair_id_].min_distance;
 }
 
 template <typename Scalar>
@@ -33,9 +33,9 @@ void FrameCollisionResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &,
 
   // Calculate vector from joint to collision p1 and joint to collision p2,
   // expressed in local world aligned
-  d.distance_ = d.geometry_.distanceResults[frame_pair_id_].nearest_points[0] -
+  d.distance_ = d.geom_data.distanceResults[frame_pair_id_].nearest_points[0] -
                 pdata.oMf[frame_id1_].translation();
-  d.distance2_ = d.geometry_.distanceResults[frame_pair_id_].nearest_points[1] -
+  d.distance2_ = d.geom_data.distanceResults[frame_pair_id_].nearest_points[1] -
                  pdata.oMf[frame_id2_].translation();
 
   d.jointToP1_.setIdentity();
@@ -61,7 +61,7 @@ void FrameCollisionResidualTpl<Scalar>::computeJacobians(const ConstVectorRef &,
   // compute the residual derivatives
   d.Jx_.setZero();
   d.Jx_.leftCols(pin_model_.nv) =
-      d.geometry_.distanceResults[frame_pair_id_].normal.transpose() *
+      d.geom_data.distanceResults[frame_pair_id_].normal.transpose() *
       (d.Jcol2_.template topRows<3>() - d.Jcol_.template topRows<3>());
 }
 
@@ -69,7 +69,7 @@ template <typename Scalar>
 FrameCollisionDataTpl<Scalar>::FrameCollisionDataTpl(
     const FrameCollisionResidualTpl<Scalar> &model)
     : Base(model.ndx1, model.nu, 1), pin_data_(model.pin_model_),
-      geometry_(pinocchio::GeometryData(model.geom_model_)),
+      geom_data(pinocchio::GeometryData(model.geom_model_)),
       Jcol_(6, model.pin_model_.nv), Jcol2_(6, model.pin_model_.nv) {
   Jcol_.setZero();
   Jcol2_.setZero();

--- a/include/aligator/utils/exceptions.hpp
+++ b/include/aligator/utils/exceptions.hpp
@@ -8,8 +8,12 @@
   throw ::aligator::RuntimeError(                                              \
       ::aligator::detail::exception_msg(__FILE__, __LINE__, __VA_ARGS__))
 
+#define ALIGATOR_OUT_OF_RANGE_ERROR(...)                                       \
+  throw ::std::out_of_range(                                                   \
+      ::aligator::detail::exception_msg(__FILE__, __LINE__, __VA_ARGS__))
+
 #define ALIGATOR_DOMAIN_ERROR(...)                                             \
-  throw std::domain_error(                                                     \
+  throw ::std::domain_error(                                                   \
       ::aligator::detail::exception_msg(__FILE__, __LINE__, __VA_ARGS__))
 
 #define ALIGATOR_WARNING(loc, ...)                                             \

--- a/tests/python/test_frames.py
+++ b/tests/python/test_frames.py
@@ -265,6 +265,49 @@ def test_frame_collision():
         assert np.allclose(fdata.Jx, fdata2.Jx, atol=ATOL)
 
 
+def test_FrameCollisionResidual_no_collision_pairs():
+    import hppfcl
+
+    fr_name1 = "larm_shoulder2_body"
+    fr_id1 = model.getFrameId(fr_name1)
+    joint_id = model.frames[fr_id1].parentJoint
+
+    fr_name2 = "rleg_elbow_body"
+    fr_id2 = model.getFrameId(fr_name2)
+    joint_id2 = model.frames[fr_id2].parentJoint
+
+    frame_SE3 = pin.SE3.Random()
+    frame_SE3_bis = pin.SE3.Random()
+    alpha = np.random.rand()
+    beta = np.random.rand()
+    gamma = np.random.rand()
+    delta = np.random.rand()
+
+    geometry = pin.GeometryModel()
+    ig_frame = geometry.addGeometryObject(
+        pin.GeometryObject(
+            "frame", fr_id1, joint_id, hppfcl.Capsule(alpha, gamma), frame_SE3
+        )
+    )
+
+    ig_frame2 = geometry.addGeometryObject(
+        pin.GeometryObject(
+            "frame2", fr_id2, joint_id2, hppfcl.Capsule(beta, delta), frame_SE3_bis
+        )
+    )
+
+    space = manifolds.MultibodyConfiguration(model)
+    ndx = space.ndx
+    x0 = space.neutral()
+    d = np.random.randn(space.ndx) * 0.1
+    d[6:] = 0.0
+    x0 = space.integrate(x0, d)
+    u0 = np.zeros(nu)
+    q0 = x0[:nq]
+
+    fun = aligator.FrameCollisionResidual(ndx, nu, model, geometry, 0)
+
+
 if __name__ == "__main__":
     import sys
     import pytest

--- a/tests/python/test_frames.py
+++ b/tests/python/test_frames.py
@@ -4,10 +4,11 @@ This test is not added to CTest when CMake does not detect Pinocchio.
 """
 
 import aligator
+from aligator import manifolds
+
 import numpy as np
 import pinocchio as pin
-
-from aligator import manifolds
+import pytest
 
 
 model = pin.buildSampleModelHumanoid()
@@ -274,11 +275,11 @@ def test_frame_collision_no_collision_pairs():
     x0 = space.integrate(x0, d)
 
     geometry = pin.buildSampleGeometryModelHumanoid(model)
-    aligator.FrameCollisionResidual(ndx, nu, model, geometry, 0)
+    with pytest.raises(IndexError, match="Provided collision pair index"):
+        aligator.FrameCollisionResidual(ndx, nu, model, geometry, 0)
 
 
 if __name__ == "__main__":
     import sys
-    import pytest
 
     sys.exit(pytest.main(sys.argv))

--- a/tests/python/test_frames.py
+++ b/tests/python/test_frames.py
@@ -193,7 +193,7 @@ def test_fly_high():
 
 
 def test_frame_collision():
-    import hppfcl
+    import coal
 
     fr_name1 = "larm_shoulder2_body"
     fr_id1 = model.getFrameId(fr_name1)
@@ -210,16 +210,16 @@ def test_frame_collision():
     gamma = np.random.rand()
     delta = np.random.rand()
 
-    geometry = pin.GeometryModel()
+    geometry = pin.buildSampleGeometryModelHumanoid(model)
     ig_frame = geometry.addGeometryObject(
         pin.GeometryObject(
-            "frame", fr_id1, joint_id, hppfcl.Capsule(alpha, gamma), frame_SE3
+            "frame", fr_id1, joint_id, coal.Capsule(alpha, gamma), frame_SE3
         )
     )
 
     ig_frame2 = geometry.addGeometryObject(
         pin.GeometryObject(
-            "frame2", fr_id2, joint_id2, hppfcl.Capsule(beta, delta), frame_SE3_bis
+            "frame2", fr_id2, joint_id2, coal.Capsule(beta, delta), frame_SE3_bis
         )
     )
     geometry.addCollisionPair(pin.CollisionPair(ig_frame, ig_frame2))
@@ -265,47 +265,16 @@ def test_frame_collision():
         assert np.allclose(fdata.Jx, fdata2.Jx, atol=ATOL)
 
 
-def test_FrameCollisionResidual_no_collision_pairs():
-    import hppfcl
-
-    fr_name1 = "larm_shoulder2_body"
-    fr_id1 = model.getFrameId(fr_name1)
-    joint_id = model.frames[fr_id1].parentJoint
-
-    fr_name2 = "rleg_elbow_body"
-    fr_id2 = model.getFrameId(fr_name2)
-    joint_id2 = model.frames[fr_id2].parentJoint
-
-    frame_SE3 = pin.SE3.Random()
-    frame_SE3_bis = pin.SE3.Random()
-    alpha = np.random.rand()
-    beta = np.random.rand()
-    gamma = np.random.rand()
-    delta = np.random.rand()
-
-    geometry = pin.GeometryModel()
-    ig_frame = geometry.addGeometryObject(
-        pin.GeometryObject(
-            "frame", fr_id1, joint_id, hppfcl.Capsule(alpha, gamma), frame_SE3
-        )
-    )
-
-    ig_frame2 = geometry.addGeometryObject(
-        pin.GeometryObject(
-            "frame2", fr_id2, joint_id2, hppfcl.Capsule(beta, delta), frame_SE3_bis
-        )
-    )
-
+def test_frame_collision_no_collision_pairs():
     space = manifolds.MultibodyConfiguration(model)
     ndx = space.ndx
     x0 = space.neutral()
     d = np.random.randn(space.ndx) * 0.1
     d[6:] = 0.0
     x0 = space.integrate(x0, d)
-    u0 = np.zeros(nu)
-    q0 = x0[:nq]
 
-    fun = aligator.FrameCollisionResidual(ndx, nu, model, geometry, 0)
+    geometry = pin.buildSampleGeometryModelHumanoid(model)
+    aligator.FrameCollisionResidual(ndx, nu, model, geometry, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
https://github.com/Simple-Robotics/aligator/issues/289#issuecomment-2832014757

Resolves #289.

## Problem description

When `FrameCollisionResidual` is initialized with a geometry that has no collision pairs, we get a segfault.