### PR TITLE
Add macro `aligator_create_python_extension()` to exported CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 LAAS-CNRS, INRIA
+# Copyright (C) 2022-2024 LAAS-CNRS, 2022-2025 INRIA
 #
 
 cmake_minimum_required(VERSION 3.16)
@@ -555,6 +555,11 @@ if(BUILD_TESTING)
 endif()
 
 # --- PACKAGING ----------------------------------------------------------------
+
+if(BUILD_PYTHON_INTERFACE)
+  file(READ extra-python-macros.cmake PACKAGE_EXTRA_MACROS)
+endif()
+
 macro(EXPORT_VARIABLE var_name var_value)
   get_directory_property(has_parent PARENT_DIRECTORY)
   if(has_parent)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -1,5 +1,5 @@
 #
-# Copyright (C) 2022-2024 LAAS-CNRS, INRIA
+# Copyright (C) 2022-2024 LAAS-CNRS, 2022-2025 INRIA
 #
 include(${JRL_CMAKE_MODULES}/python.cmake)
 if(GENERATE_PYTHON_STUBS)

--- a/extra-python-macros.cmake
+++ b/extra-python-macros.cmake
@@ -1,0 +1,20 @@
+# ------
+# aligator_add_python_extension
+#
+#
+# ------
+function(aligator_create_python_extension name)
+  message(STATUS "Adding aligator Python C++ extension ${name}")
+  set(options WITH_SOABI)
+  cmake_parse_arguments(arg "${options}" "" "" ${ARGN})
+  set(_parse_oneValueArgs)
+  foreach(op IN LISTS options)
+    if(${arg_${op}})
+      list(APPEND _parse_oneValueArgs ${op})
+    endif()
+  endforeach()
+  set(_sources ${arg_UNPARSED_ARGUMENTS})
+
+  Python3_add_library(${name} ${_parse_oneValueArgs} ${_sources})
+  target_link_libraries(${name} PRIVATE eigenpy::eigenpy aligator::aligator)
+endfunction()

--- a/extra-python-macros.cmake
+++ b/extra-python-macros.cmake
@@ -17,4 +17,5 @@ function(aligator_create_python_extension name)
 
   Python3_add_library(${name} ${_parse_oneValueArgs} ${_sources})
   target_link_libraries(${name} PRIVATE eigenpy::eigenpy aligator::aligator)
+  target_compile_definitions(${name} PRIVATE PYTHON_MODULE_NAME=${name})
 endfunction()


### PR DESCRIPTION
- **[cmake] Add CMake utility aligator_create_python_extension() to generated config file**
- **Inject Python extension module name**

We do this using `PACKAGE_EXTRA_MACROS`, into which I read the contents of the extra macro file.

Resolves #279

cc @Tordjx
