### PR TITLE
[python] make BlkMatrixPythonVisitor an incomplete type when template argument is wrong

### DIFF
--- a/bindings/python/include/aligator/python/blk-matrix.hpp
+++ b/bindings/python/include/aligator/python/blk-matrix.hpp
@@ -5,12 +5,12 @@ namespace aligator {
 namespace python {
 namespace bp = boost::python;
 
-template <typename BlockMatrixType>
-struct BlkMatrixPythonVisitor
-    : bp::def_visitor<BlkMatrixPythonVisitor<BlockMatrixType>> {
+template <typename BlockMatrixType> struct BlkMatrixPythonVisitor;
 
-  enum { N = BlockMatrixType::N, M = BlockMatrixType::M };
-  using MatrixType = typename BlockMatrixType::MatrixType;
+template <typename MatrixType, int N, int M>
+struct BlkMatrixPythonVisitor<BlkMatrix<MatrixType, N, M>>
+    : bp::def_visitor<BlkMatrixPythonVisitor<BlkMatrix<MatrixType, N, M>>> {
+  using BlockMatrixType = BlkMatrix<MatrixType, N, M>;
   using RefType = Eigen::Ref<MatrixType>;
 
   using Self = BlkMatrixPythonVisitor<BlockMatrixType>;


### PR DESCRIPTION
Backport from #243.