### PR TITLE
solvers : make proxddp algo's `Results` class copyable again (in C++ and Python)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- solvers : make proxddp algo's Results class copyable again (in C++ and Python) (https://github.com/Simple-Robotics/aligator/pull/322)
+
 ## [0.15.0] - 2025-05-23
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - solvers : make proxddp algo's Results class copyable again (in C++ and Python) (https://github.com/Simple-Robotics/aligator/pull/322)
+- python/visitors : also set `__copy__` method on exposed class with CopyableVisitor (https://github.com/Simple-Robotics/aligator/pull/322)
 
 ## [0.15.0] - 2025-05-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - solvers : make proxddp algo's Results class copyable again (in C++ and Python) (https://github.com/Simple-Robotics/aligator/pull/322)
-- python/visitors : also set `__copy__` method on exposed class with CopyableVisitor (https://github.com/Simple-Robotics/aligator/pull/322)
+- python/visitors : also set `__copy__` method on exposed class with `CopyableVisitor` (https://github.com/Simple-Robotics/aligator/pull/322)
+- python : make `Results` copyable (using `CopyableVisitor`) (https://github.com/Simple-Robotics/aligator/pull/322)
 
 ## [0.15.0] - 2025-05-23
 

--- a/bindings/python/include/aligator/python/visitors.hpp
+++ b/bindings/python/include/aligator/python/visitors.hpp
@@ -37,7 +37,8 @@ struct CreateDataPolymorphicPythonVisitor
 template <typename T>
 struct CopyableVisitor : bp::def_visitor<CopyableVisitor<T>> {
   template <typename PyClass> void visit(PyClass &obj) const {
-    obj.def("copy", &copy, bp::arg("self"), "Returns a copy of this.");
+    obj.def("copy", &copy, bp::arg("self"), "Returns a copy of this.")
+        .def("__copy__", &copy, bp::arg("self"), "Returns a copy of this.");
   }
 
 private:

--- a/bindings/python/include/aligator/python/visitors.hpp
+++ b/bindings/python/include/aligator/python/visitors.hpp
@@ -12,13 +12,6 @@ namespace bp = boost::python;
 bp::arg operator""_a(const char *argname, std::size_t);
 
 template <typename T>
-struct ClonePythonVisitor : bp::def_visitor<ClonePythonVisitor<T>> {
-  template <typename PyT> void visit(PyT &obj) const {
-    obj.def("clone", &T::clone, bp::args("self"), "Clone the object.");
-  }
-};
-
-template <typename T>
 struct CreateDataPythonVisitor : bp::def_visitor<CreateDataPythonVisitor<T>> {
   template <typename Pyclass> void visit(Pyclass &obj) const {
     obj.def("createData", &T::createData, bp::args("self"),

--- a/bindings/python/include/aligator/python/visitors.hpp
+++ b/bindings/python/include/aligator/python/visitors.hpp
@@ -1,5 +1,5 @@
 /// @file
-/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, 2022-2025 INRIA
 #pragma once
 
 #include <eigenpy/fwd.hpp>

--- a/bindings/python/src/expose-solver-prox.cpp
+++ b/bindings/python/src/expose-solver-prox.cpp
@@ -112,7 +112,8 @@ void exposeProxDDP() {
       .def_readonly("lams", &Results::lams)
       .def_readonly("vs", &Results::vs)
       .def(PrintableVisitor<Results>())
-      .def(PrintAddressVisitor<Results>());
+      .def(PrintAddressVisitor<Results>())
+      .def(CopyableVisitor<Results>());
 
   using SolverType = SolverProxDDPTpl<Scalar>;
   using ls_variant_t = SolverType::LinesearchVariant::variant_t;

--- a/bindings/python/src/expose-solver-prox.cpp
+++ b/bindings/python/src/expose-solver-prox.cpp
@@ -1,5 +1,5 @@
 /// @file
-/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, 2022-2025 INRIA
 #include "aligator/python/fwd.hpp"
 #include "aligator/python/visitors.hpp"
 #include "aligator/python/solvers.hpp"

--- a/bindings/python/src/expose-solver-prox.cpp
+++ b/bindings/python/src/expose-solver-prox.cpp
@@ -103,7 +103,7 @@ void exposeProxDDP() {
       .def_readonly("control_dual_infeas", &Workspace::control_dual_infeas)
       .def(PrintableVisitor<Workspace>());
 
-  bp::class_<Results, bp::bases<ResultsBaseTpl<Scalar>>, boost::noncopyable>(
+  bp::class_<Results, bp::bases<ResultsBaseTpl<Scalar>>>(
       "Results", "Results struct for proxDDP.",
       bp::init<const TrajOptProblem &>(("self"_a, "problem")))
       .def("cycleAppend", &Results::cycleAppend, ("self"_a, "problem", "x0"),
@@ -111,7 +111,8 @@ void exposeProxDDP() {
       .def_readonly("al_iter", &Results::al_iter)
       .def_readonly("lams", &Results::lams)
       .def_readonly("vs", &Results::vs)
-      .def(PrintableVisitor<Results>());
+      .def(PrintableVisitor<Results>())
+      .def(PrintAddressVisitor<Results>());
 
   using SolverType = SolverProxDDPTpl<Scalar>;
   using ls_variant_t = SolverType::LinesearchVariant::variant_t;

--- a/include/aligator/solvers/proxddp/results.hpp
+++ b/include/aligator/solvers/proxddp/results.hpp
@@ -1,10 +1,9 @@
 /// @file
-/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, INRIA
+/// @copyright Copyright (C) 2022-2024 LAAS-CNRS, 2022-2025 INRIA
 #pragma once
 
 #include "aligator/solvers/results-base.hpp"
 #include <fmt/ostream.h>
-#include <sstream>
 
 namespace aligator {
 

--- a/include/aligator/solvers/proxddp/results.hpp
+++ b/include/aligator/solvers/proxddp/results.hpp
@@ -29,8 +29,8 @@ template <typename _Scalar> struct ResultsTpl final : ResultsBaseTpl<_Scalar> {
   explicit ResultsTpl()
       : Base() {}
 
-  ResultsTpl(const ResultsTpl &) = delete;
-  ResultsTpl &operator=(const ResultsTpl &) = delete;
+  ResultsTpl(const ResultsTpl &) = default;
+  ResultsTpl &operator=(const ResultsTpl &) = default;
 
   ResultsTpl(ResultsTpl &&) = default;
   ResultsTpl &operator=(ResultsTpl &&) = default;


### PR DESCRIPTION
In Python, users can now do
```python
# res is an `aligator.Results`
res_copy = res.copy()
# or using the copy module, hence the `__copy__` method
res_copy = copy.copy(res)
```

Resolves #321 