### PR TITLE
gh-pages workflow : use pixi

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -18,22 +18,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: conda-incubator/setup-miniconda@v3
         with:
-          miniforge-version: latest
-          channels: conda-forge
-          mamba-version: "*"
-          python-version: "3.12"
-          activate-environment: doc
-          conda-remove-defaults: "true"
-      - name: Dependencies
-        shell: bash -l {0}
-        run: |
-          # Compilation related dependencies
-          mamba install cmake make pkg-config doxygen graphviz
+          submodules: recursive
 
-          # Main dependencies
-          mamba install eigen pinocchio fmt example-robot-data
+      - uses: prefix-dev/setup-pixi@v0.8.1
+        with:
+          cache: true
+          environments: default
 
       - name: Print environment
         shell: bash -l {0}
@@ -42,22 +33,11 @@ jobs:
           mamba list
           env
 
-      - name: Configure
-        shell: bash -l {0}
-        run: |
-          git submodule update --init
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} -DCMAKE_BUILD_TYPE=Release -DBUILD_PYTHON_INTERFACE:BOOL=OFF\
-            -DPYTHON_EXECUTABLE=$(which python3) -DBUILD_DOCUMENTATION:BOOL=ON \
-            -DBUILD_BENCHMARKS:BOOL=OFF -DINSTALL_DOCUMENTATION:BOOL=ON -DBUILD_TESTING:BOOL=OFF \
-            -DBUILD_CROCODDYL_COMPAT:BOOL=OFF
-
       - name: Build documentation
         shell: bash -l {0}
         run: |
-          cd build
-          cmake --build . --config Release --target doc
+          pixi run configure
+          cmake --build build --config Release --target doc
 
       - name: Upload to GitHub pages
         uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
@jorisv I'm proposing this change because fmt12 was just released on conda-forge and it broke this workflow -- because this workflow doesn't check for dependency versions 🤡 