### PR TITLE
add missing link against Eigen3::Eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,7 +368,11 @@ function(create_library)
   if(BUILD_WITH_OPENMP_SUPPORT)
     target_link_libraries(${PROJECT_NAME} PUBLIC OpenMP::OpenMP_CXX)
   endif()
-  target_link_libraries(${PROJECT_NAME} PUBLIC Eigen3::Eigen fmt::fmt PRIVATE mimalloc)
+  target_link_libraries(
+    ${PROJECT_NAME}
+    PUBLIC Eigen3::Eigen fmt::fmt
+    PRIVATE mimalloc
+  )
   # set the install-tree include dirs used by dependent projects to consume this
   # target
   target_include_directories(


### PR DESCRIPTION
Eigen3::Eigen was missing.

Fixes build issue with the `default` env. 