### PR TITLE
modelling/spaces : add getter for underlying `pin::LieGroup` object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Support the new Pinocchio 4 release (https://github.com/Simple-Robotics/aligator/pull/390)
+- manifolds: add `PinocchioLieGroup::lieGroup()` getter, expose to Python
 
 ### Changed
 - Deprecate `<aligator/modelling/dynamics/context.hpp>` (https://github.com/Simple-Robotics/aligator/pull/390)

--- a/bindings/python/src/modelling/multibody/expose-pinocchio-manifolds.cpp
+++ b/bindings/python/src/modelling/multibody/expose-pinocchio-manifolds.cpp
@@ -21,8 +21,10 @@ using PolyManifold = xyz::polymorphic<Manifold>;
 /// and no-arg default constructor.
 template <typename LieGroup>
 void exposeLieGroup(const char *name, const char *docstring) {
-  bp::class_<PinocchioLieGroup<LieGroup>, bp::bases<Manifold>>(
-      name, docstring, bp::init<>("self"_a))
+  using wrapper_t = PinocchioLieGroup<LieGroup>;
+  bp::class_<wrapper_t, bp::bases<Manifold>>(name, docstring,
+                                             bp::init<>("self"_a))
+      .add_property("lg", &wrapper_t::lieGroup)
       .def(PolymorphicVisitor<PolyManifold>())
       .enable_pickling_(true);
 }

--- a/include/aligator/modelling/spaces/pinocchio-groups.hpp
+++ b/include/aligator/modelling/spaces/pinocchio-groups.hpp
@@ -14,15 +14,16 @@ namespace pin = pinocchio;
 /// Type trait. Indicates whether @tparam G is derived from
 /// pinocchio::LieGroupBase.
 template <typename G>
-inline constexpr bool is_pinocchio_lie_group =
-    std::is_base_of_v<pin::LieGroupBase<G>, G>;
+inline constexpr bool is_pinocchio_lie_group_v =
+    is_tpl_base_of_v<pin::LieGroupBase, G>;
 
 /// @brief  Wrap a Pinocchio Lie group into a ManifoldAbstractTpl object.
 ///
-template <typename G, std::enable_if_t<is_pinocchio_lie_group<G>> * = nullptr>
-struct PinocchioLieGroup : ManifoldAbstractTpl<typename G::Scalar> {
+template <typename LieGroup_>
+struct PinocchioLieGroup : ManifoldAbstractTpl<typename LieGroup_::Scalar> {
 public:
-  using LieGroup = G;
+  using LieGroup = LieGroup_;
+  static_assert(is_pinocchio_lie_group_v<LieGroup>);
   using Scalar = typename LieGroup::Scalar;
   using Base = ManifoldAbstractTpl<Scalar>;
   using Base::ndx;
@@ -51,6 +52,7 @@ public:
   }
 
   operator LieGroup() const { return lg_; }
+  LieGroup lieGroup() const { return lg_; }
 
   bool isNormalized(const ConstVectorRef &x) const {
     if (x.size() < nx())


### PR DESCRIPTION
- use is_tpl_base_of_v for trait assert
- add getter for LieGroup object